### PR TITLE
description for env vars in Windows

### DIFF
--- a/usage/beforeyoubegin.rst
+++ b/usage/beforeyoubegin.rst
@@ -128,18 +128,26 @@ which requires a license for all remote systems you plan on scanning.
 License Injection via Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Instead of dealing with license files, you can provide a specific license via
-the execution environment of THOR. This is particularly useful for automation
-purposes, e.g., if THOR is run in a nested environment like a container.
+Instead of dealing with license files, you can provide a specific license via  
+the execution environment of THOR. This is particularly useful for automation  
+purposes, such as when running THOR in a nested environment like a container.
 
-Use a valid license file to store its content as a base64-encoded string in the
-environment variable ``THOR_LICENSE``:
+A valid license file can be stored as a **base64-encoded string** in the  
+environment variable ``THOR_LICENSE`` and used automatically by THOR.
+
+**Linux**
 
 .. code-block:: console
 
    nextron@unix:~$ export THOR_LICENSE=$(base64 < /path/to/thor.lic)
 
-Then run THOR as usual.
+**Windows**
+
+.. code-block:: powershell
+
+   $env:THOR_LICENSE = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes("C:\path\to\thor.lic")) && thor.exe
+
+Once the environment variable is set, **run THOR as usual**. It will automatically detect and use the provided license.
 
 Upgrade THOR and Update The Signatures
 --------------------------------------

--- a/usage/beforeyoubegin.rst
+++ b/usage/beforeyoubegin.rst
@@ -145,7 +145,7 @@ environment variable ``THOR_LICENSE`` and used automatically by THOR.
 
 .. code-block:: powershell
 
-   $env:THOR_LICENSE = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes("C:\path\to\thor.lic")) && thor.exe
+   $env:THOR_LICENSE = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes("C:\path\to\thor.lic"))
 
 Once the environment variable is set, **run THOR as usual**. It will automatically detect and use the provided license.
 


### PR DESCRIPTION
add description for Windows

![image](https://github.com/user-attachments/assets/0fbdbcd9-4ff8-4d98-b556-33f9f684c257)


I tested it

<img width="983" alt="Screenshot 2025-02-04 at 09 47 52" src="https://github.com/user-attachments/assets/b6a8fc34-fc88-4a1a-a8ad-5d85e48d6932" />


<img width="981" alt="Screenshot 2025-02-04 at 09 47 33" src="https://github.com/user-attachments/assets/198ebb5e-ca65-4bb4-857b-7446193d482a" />
