### PR TITLE
chore: add missing hint about trailing slashes of external variable

### DIFF
--- a/signatures/yara.rst
+++ b/signatures/yara.rst
@@ -208,8 +208,8 @@ These external variables are:
 
 * **filepath**
 
-  * file path without file name
-  * Example: ``C:\temp``
+  * file path without file name and without trailing path delimiter
+  * Example: ``C:\temp`` or ``/var/log``
 
 * **extension**
 


### PR DESCRIPTION
chore: add missing hint about trailing slashes of external variable filepath