### PR TITLE
docs: refine requirements chapter wording

### DIFF
--- a/core/requirements.rst
+++ b/core/requirements.rst
@@ -80,15 +80,24 @@ THOR Legacy is available for the systems listed below.
 THOR for AIX
 ^^^^^^^^^^^^
 
-We provide a dedicated THOR package for IBM AIX 7.2 and 7.3. Because THOR
-includes native components, build and runtime compatibility are important.
-Our standard approach is to build on the oldest supported AIX level where
-possible, test on both baseline and newer supported levels, and aim for
-forward-compatible execution across the supported AIX 7.2/7.3 range. This
-helps us minimize the number of platform variants while keeping support
-boundaries clear and technically realistic. Older AIX versions are not
-supported. Contact us if you would like to validate compatibility in your
-environment with a test license.
+We build and maintain native THOR scanner packages for IBM AIX. Because
+the package includes Go-based code and native C components, build
+environment, compiler and runtime dependencies, and binary compatibility
+are important factors for packaging, testing, and support.
+
+Our current AIX focus is on IBM AIX 7.2 and 7.3. Example environments
+currently available to us include AIX 7.2 TL5 SP11 and AIX 7.3 TL3 SP0.
+
+The exact build baseline, regular test matrix, and minimum supported TL/SP
+level are still being evaluated. Current compatibility guidance indicates
+that forward compatibility is generally more realistic than backward
+compatibility on AIX, so binaries built on older supported levels are more
+likely to run on newer supported levels than the reverse.
+
+Our current objective is to establish a compatibility-oriented strategy
+for AIX 7.2 and 7.3 that provides reliable support coverage without
+unnecessary build fragmentation. Contact us if you would like to validate
+compatibility in your environment with a test license.
 
 Unsupported
 ^^^^^^^^^^^

--- a/core/requirements.rst
+++ b/core/requirements.rst
@@ -80,24 +80,13 @@ THOR Legacy is available for the systems listed below.
 THOR for AIX
 ^^^^^^^^^^^^
 
-We build and maintain native THOR scanner packages for IBM AIX. Because
-the package includes Go-based code and native C components, build
-environment, compiler and runtime dependencies, and binary compatibility
-are important factors for packaging, testing, and support.
+We provide native THOR scanner packages for IBM AIX.
 
-Our current AIX focus is on IBM AIX 7.2 and 7.3. Example environments
+THOR for AIX supports IBM AIX 7.2 and 7.3. Build and test environments
 currently available to us include AIX 7.2 TL5 SP11 and AIX 7.3 TL3 SP0.
 
-The exact build baseline, regular test matrix, and minimum supported TL/SP
-level are still being evaluated. Current compatibility guidance indicates
-that forward compatibility is generally more realistic than backward
-compatibility on AIX, so binaries built on older supported levels are more
-likely to run on newer supported levels than the reverse.
-
-Our current objective is to establish a compatibility-oriented strategy
-for AIX 7.2 and 7.3 that provides reliable support coverage without
-unnecessary build fragmentation. Contact us if you would like to validate
-compatibility in your environment with a test license.
+Older AIX versions are not supported. If you would like to validate
+compatibility in your environment, please contact us for a test license.
 
 Unsupported
 ^^^^^^^^^^^

--- a/core/requirements.rst
+++ b/core/requirements.rst
@@ -6,21 +6,22 @@
 Requirements
 ============
 
-THOR runs in any Windows, Linux, macOS, or AIX environment without any
-further requirements. Everything needed is already included in the
-program package.
+THOR runs on supported Windows, Linux, macOS, and AIX systems without
+additional runtime requirements. Everything required to run THOR is
+included in the program package.
 
-To use the full potential of THOR, you should execute it with administrative
-privileges - ``LOCAL_SYSTEM`` on Windows and ``root`` on Linux/macOS/AIX
-systems.
+For full scan coverage, we recommend running THOR with administrative
+privileges: ``LOCAL_SYSTEM`` on Windows and ``root`` on Linux, macOS, and
+AIX.
 
 Operating Systems
 -----------------
 
-The following operating systems and their versions are the **minimum
-requirements** to run THOR. Any newer version will also work.
+The following operating systems and versions are the **minimum
+requirements** to run THOR. Newer releases within these platform families
+are generally expected to work as well.
 
-.. list-table:: 
+.. list-table::
   :widths: 30, 30, 40
   :header-rows: 1
 
@@ -34,87 +35,94 @@ requirements** to run THOR. Any newer version will also work.
     - Windows Server 2016
     -
   * - Ubuntu 16 LTS
-    - 
+    -
     -
   * - Debian 9
-    - 
-    - 
+    -
+    -
 
 Legacy Systems
 ^^^^^^^^^^^^^^
 
-These versions are scannable with THOR Legacy. The legacy version
-of THOR is usually running on those systems, but if you encounter
-any problems, we will not be able to fix them. Contact us for
-details on how to download and use THOR Legacy.
+THOR Legacy is available for the systems listed below.
 
-.. list-table:: 
-  :widths: 50, 25, 25
+.. list-table::
+  :widths: 65, 35
   :header-rows: 1
 
   * - OS
     - Architecture
-    - Support
   * - Windows Server 2012
     - x86 and x64
-    - yes
   * - Windows Server 2008 R2
     - x86 and x64
-    - yes
   * - Windows Server 2008
     - x86 and x64
-    - no
   * - Windows 8
     - x86 and x64
-    - yes
   * - Windows 7
     - x86 and x64
-    - yes
   * - Windows XP
     - x86 and x64
-    - no
   * - CentOS 6
     - x86 and x64
-    - yes
+
+.. note::
+   THOR Legacy packages are available for all systems listed above. We
+   continue to provide updated signature packages and, in some cases,
+   updated program versions for these legacy releases. Support is limited:
+   these versions run on our test systems, but we cannot guarantee
+   successful operation on every legacy installation. Compatibility depends
+   on factors such as service packs, installed KB updates, drivers, and
+   third-party software. Contact us for details on how to download and use
+   THOR Legacy.
 
 THOR for AIX
 ^^^^^^^^^^^^
 
-We offer a special version for AIX. Currently only a small number of versions
-are supported. We are extensively testing THOR on AIX 7.3 with Power9. 
-THOR for AIX will not run on older versions of AIX. If you are running a newer
-version and are interested in THOR for AIX, we can always provide a test license
-to verify if everything is working as expected.
+We provide a dedicated THOR package for IBM AIX 7.2 and 7.3. Because THOR
+includes native components, build and runtime compatibility are important.
+Our standard approach is to build on the oldest supported AIX level where
+possible, test on both baseline and newer supported levels, and aim for
+forward-compatible execution across the supported AIX 7.2/7.3 range. This
+helps us minimize the number of platform variants while keeping support
+boundaries clear and technically realistic. Older AIX versions are not
+supported. Contact us if you would like to validate compatibility in your
+environment with a test license.
 
 Unsupported
 ^^^^^^^^^^^
 
-* VMWare ESX - see https://knowledge.broadcom.com/external/article?legacyId=1036544
-* many others 
+* VMware ESX - see https://knowledge.broadcom.com/external/article?legacyId=1036544
+* Operating systems or architectures for which no native THOR package is
+  available
+* Appliance or embedded environments that cannot run a native THOR package
 
 If you need to perform an analysis on unsupported operating systems or architectures, contact us
 for a solution using `THOR Thunderstorm <https://www.nextron-systems.com/thor-thunderstorm/>`__
 and `Thunderstorm collectors <https://github.com/NextronSystems/thunderstorm-collector>`__.
 
-We have productive setups with our customers involving the file collection from: 
+We also have production deployments with customers that rely on file
+collection from:
 
-* SPARC Solaris 
+* SPARC Solaris
 * RHEL Linux 4
 * Citrix Netscaler
 * ICS environments with Windows XP embedded systems
-* VMWare ESX (see this `blog post <https://www.nextron-systems.com/2021/06/07/analyze-vmware-esx-systems-with-thor-thunderstorm/>`__)
+* VMware ESX (see this `blog post <https://www.nextron-systems.com/2021/06/07/analyze-vmware-esx-systems-with-thor-thunderstorm/>`__)
 
 Update Servers
 --------------
 
-To download the newest updates for THOR and our signatures, you need an active internet connection.
-The endpoint performing the update needs to reach our update servers to do this.
+An active internet connection is required only if you want to update THOR
+and its signature sets. The system performing the update must be able to
+reach our update servers.
 
-For a detailed and up to date list of our update and licensing
+For a detailed and up-to-date list of our update and licensing
 servers, please visit https://www.nextron-systems.com/hosts/.
 
 .. hint::
-  You do not need an active internet connection to scan an endpoint. This is only needed
-  if you want to update to the latest THOR and signature versions. There are special
-  licenses for special circumstances, for example when the licensed system does not
-  have internet access. If you need such a special license, please reach out to us.
+  THOR does not require an active internet connection to scan a system.
+  Internet access is only required to update THOR and its signature sets.
+  We also offer licensing options for environments without internet access.
+  Contact us if you need an offline licensing setup.


### PR DESCRIPTION
## Summary
- tighten the requirements chapter wording to avoid blanket compatibility claims
- clarify legacy package availability and limited-support expectations
- rewrite the AIX, unsupported-platform, and update connectivity sections for clearer support boundaries

## Testing
- not run (documentation-only change)