### PR TITLE
docs: refine version selection wording

### DIFF
--- a/core/version.rst
+++ b/core/version.rst
@@ -3,13 +3,13 @@
 Which version to use?
 =====================
 
-The different THOR versions offered can be a bit confusing in the beginning.
-To avoid more confusion down the line, you should read the below information.
+The available THOR versions can be confusing at first. This section
+explains which variant to use in which situation.
 
 Which THOR Variant?
 -------------------
 
-We offer THOR in different variants.
+THOR is available in different variants.
 
 * :ref:`core/version:thor`
 * :ref:`core/version:thor techpreview`
@@ -23,19 +23,20 @@ We offer THOR in different variants.
 THOR
 ^^^^
 
-The default version of THOR is the most stable version, intensively tested and
-without any broadly tested performance and detection tweaks.
+The default version of THOR is the most stable and most extensively
+tested version. It is recommended for production use when stability is
+the priority.
 
 The default version should be used for:
 
 * Scan sweeps on hundreds or thousands of systems
 * Continuous compromise assessments on hundreds or thousands of systems
-* Systems with high requirements on stability
+* Systems with high stability requirements
 
 THOR TechPreview
 ^^^^^^^^^^^^^^^^
 
-The TechPreview version is focused on detection and speed. This
+The TechPreview version is focused on detection coverage and speed. This
 `blog post <https://www.nextron-systems.com/2020/08/31/introduction-thor-techpreview/>`__
 contains more information on the differences.
 
@@ -45,7 +46,8 @@ The TechPreview version should be used for:
 * Dropzone mode scanning
 * Image scanning
 * THOR Thunderstorm setups
-* Single system live forensics on systems that don't have the highest priority on stability
+* Single-system live forensics on systems where maximum stability is not
+  the highest priority
 
 You can find the information on how to get the TechPreview version in
 the `THOR Util manual <https://thor-util-manual.nextron-systems.com/en/latest/usage/download-packages.html#thor-techpreview-version>`__.
@@ -53,8 +55,9 @@ the `THOR Util manual <https://thor-util-manual.nextron-systems.com/en/latest/us
 THOR Legacy
 ^^^^^^^^^^^
 
-THOR Legacy is a stripped-down version that includes all modules that can be used
-on outdated operating systems. This
+THOR Legacy is a reduced version intended for outdated operating
+systems. It includes the modules that can be supported on those
+platforms. This
 `blog post <https://www.nextron-systems.com/2020/12/17/thor-10-legacy-for-windows-xp-and-windows-2003/>`__
 contains more information on the legacy version.
 
@@ -71,56 +74,54 @@ The legacy version lacks:
 * HTML report generation
 
 .. note::
-   We only offer limited support for this version, since we cannot guarantee a successful
-   stable scan on platforms that have already been deprecated.
+   We offer only limited support for this version and cannot guarantee
+   stable operation on every deprecated platform.
 
-To use THOR Legacy, you need a special license. Contact sales to get more information regarding
-Legacy licenses.
+To use THOR Legacy, you need a special license. Contact sales for more
+information about Legacy licenses.
 
-To download THOR Legacy, you can either download it directly from
-our portal (recommended; continue at step 5), or follow these steps:
+To download THOR Legacy, either download it directly from our portal
+(recommended; continue with step 5) or use THOR Util as follows:
 
 1. Download a normal THOR package (non-legacy)
 2. Use thor-util to download THOR Legacy:
 
    ``thor-util.exe download --legacy -t thor10-win``
 
-3. You will get a zip file with the following name:
+3. You will receive a ZIP file with a name similar to:
 
    ``thor-win-10.6.20_<date>-<time>.zip``
 
-4. The content of this zip file should be as follows:
+4. The ZIP file contains the following files:
 
    .. figure:: ../images/thor_legacy_content.png
       :alt: THOR Legacy content
 
-5. You can now transfer this package to your Legacy system. Please do an upgrade
-   before you start using this:
+5. Transfer the package to your legacy system. Before using it, run:
 
    ``thor-legacy-util.exe upgrade``
 
    ``thor-legacy-util.exe update``
 
-6. Place your Legacy license inside this folder and start using THOR Legacy
+6. Place your Legacy license in this folder and start using THOR Legacy.
 
 Which Architecture?
 -------------------
 
-You will find a 32 and 64-bit version of the executable in the program folder. Never run
-the 32-bit version of THOR named ``thor.exe`` on a 64-bit system. The 32-bit version has some
-limitations that the 64-bit version doesn't have (memory usage, sees different folders
-on disk and registry versions).
+THOR packages include both 32-bit and 64-bit executables. Never run the
+32-bit THOR binary named ``thor.exe`` on a 64-bit system. Compared with
+the 64-bit version, the 32-bit binary has limitations such as lower
+available memory and different views of the file system and registry.
 
 Make sure to run the correct binary for your target architecture.
 
 What Command Line Flags?
 ------------------------
 
-THOR was built to be production ready. That means 99% of the time you
-do not need to specify any extra flags. Our recommended way to use THOR
-is **without any additional command line flags**.
+THOR is designed for production use. In most cases, you do not need to
+specify additional command-line flags. Our recommended way to use THOR
+is **without any additional command-line flags**.
 
-However, special circumstances can lead to different requirements and
-thus a different set of command line flags. See chapter
+However, special circumstances can require different settings and
+therefore a different set of command-line flags. See chapter
 :ref:`scanning/using-thor:using thor` for often used flags.
-


### PR DESCRIPTION
## Summary
- improve the wording and guidance on the Which version to use page
- clarify the descriptions of THOR, TechPreview, and THOR Legacy
- tighten the architecture and command-line flag sections for clearer user guidance

## Testing
- not run (documentation-only change)