### PR TITLE
docs: refine maintenance chapter wording

### DIFF
--- a/core/maintenance.rst
+++ b/core/maintenance.rst
@@ -3,15 +3,15 @@
 Maintenance
 ===========
 
-This chapter focuses on the maintenance aspect of THOR.
-We will explain how to update THOR and its signatures,
-using different signature versions, or including signatures
-from the `YARA Forge <https://yarahq.github.io/>`_ project.
+This chapter covers routine THOR maintenance. It explains how to update
+THOR and its signatures, how to use different signature variants, and
+how to include signatures from the
+`YARA Forge <https://yarahq.github.io/>`_ project.
 
 Upgrade THOR
 ------------
 
-Run the following command to update THOR and its Signatures:
+Run the following command to update THOR and its signatures:
 
 Windows:
 
@@ -25,15 +25,15 @@ Linux:
 
    nextron@unix:~/Documents/thor$ ./thor-util upgrade
 
-It is **important** that you update THOR before running it for the first time,
-since the downloaded version, or the contained signatures, could contain an
-older version.
+We strongly recommend updating THOR before running it for the first
+time, because the downloaded package or the included signatures may
+already be out of date.
 
 .. note::
-   The upgrade requires a valid license for the host that performs the update.
-   If you don't want to use a license for that host, ask us for a ``silent license``,
-   which can be used for all kinds of testing purposes and also allows to update THOR
-   and its signatures.
+   The upgrade requires a valid license for the host that performs the
+   update. If you do not want to use a regular license on that host,
+   ask us for a ``silent license``. It can be used for testing purposes
+   and also allows THOR and signature updates.
 
 Update Signatures
 -----------------
@@ -55,16 +55,17 @@ Linux:
 Use Preview Signatures
 ----------------------
 
-We offer a "preview" of our newest signatures, which contains the newest rules.
-Those signatures have been processed by our automated pipeline and passed the
-quality check, however the manual testing of those new rules did not take place yet.
+We provide preview signatures that contain the newest rules. These
+signatures have passed our automated pipeline and quality checks, but
+new rules may not yet have completed manual testing.
 
-We have those signatures to offer the newest rules to our customers in time critical
-engagements. You have to carefully consider if the potential higher rate of false positive
-warrants the usage of those rules. We generally recommend to only use those rules if
-the currently available signatures are a few days old.
+Preview signatures are intended for time-critical engagements where the
+latest detections are more important than minimizing false positives.
+Use them carefully, as they may produce a higher false positive rate. In
+general, we recommend using them only if the regular signature set is a
+few days old.
 
-Run the following command to get the newest "preview" signatures:
+Run the following command to download the latest preview signatures:
 
 Windows:
 
@@ -81,7 +82,7 @@ Linux:
 Use YARA Forge Signatures
 -------------------------
 
-You can include additional YARA Signatures from the
+You can include additional YARA signatures from the
 `YARA Forge <https://yarahq.github.io/>`_ project.
 
 The following rulesets are available:
@@ -104,9 +105,10 @@ Linux:
 
    nextron@unix:~/Documents/thor$ ./thor-util yara-forge download --ruleset core
 
-You can only have one ruleset active. Downloading a different ruleset
-will override the old one. The ruleset will be updated when running a normal
-update or upgrade of THOR. You can remove a ruleset with the following command:
+Only one ruleset can be active at a time. Downloading a different
+ruleset replaces the current one. The selected ruleset is updated during
+a regular THOR update or upgrade. You can remove a ruleset with the
+following command:
 
 Windows:
 
@@ -121,21 +123,20 @@ Linux:
    nextron@unix:~/Documents/thor$ ./thor-util yara-forge remove
 
 .. important::
-   Please read carefully what the rulesets are designed for and when to use
-   them. In any case, usage of those rulesets could result in longer runtime
-   of your THOR scans.
+   Review what each ruleset is designed for before enabling it. These
+   rulesets may increase THOR scan runtime.
 
 Grant Full Disk Access on macOS
 -------------------------------
 
-THOR requires Full Disk Access (FDA) for some data like Mail, Messages and certain
-administrative settings for all users, while scanning macOS, although THOR itself
-must be executed with administrative privileges.
+THOR requires Full Disk Access (FDA) on macOS to access certain data,
+such as Mail, Messages, and some administrative settings for all users.
+THOR itself must still be executed with administrative privileges.
 
-You can grant FDA to ``Terminal`` (as executing application) on demand while scanning,
-by allowing access when prompted. Alternatively, you can grant access before, to perform
-the scan unattended. Please keep in mind that also administrative privileges on the
-machine are needed to perform this change.
+You can grant FDA to ``Terminal`` (the executing application) when
+prompted during a scan. Alternatively, you can grant access in advance
+if you want to run the scan unattended. Administrative privileges on the
+Mac are required to make this change.
 
 To do this, navigate on your Mac to ``System Settings`` > ``Privacy & Security`` > ``Full Disk Access``:
 
@@ -145,7 +146,7 @@ To do this, navigate on your Mac to ``System Settings`` > ``Privacy & Security``
 
    System Settings View
 
-You need to add ``Terminal`` to the listed application.
+Add ``Terminal`` to the list of applications.
 
 .. figure:: ../images/macos_fulldiskaccess_terminal.png
    :width: 500
@@ -153,52 +154,50 @@ You need to add ``Terminal`` to the listed application.
 
    Full Disk Access View
 
-After your scan has finished, you can disable FDA for Terminal and reenable when scanning again.
+After the scan finishes, you can disable FDA for Terminal and enable it
+again before future scans.
 
 Add Command Line Completions (optional)
 ---------------------------------------
 
-Since version 10.7.15, THOR offers shell completions for browsing the flags. These completions can be generated by using:
+Since version 10.7.15, THOR can generate shell completions for browsing
+available flags:
 
-   ``thor-linux-64 --completions <bash/zsh/fish/powershell>``
+.. code-block:: console
 
-This generates a snippet for the specified shell that can be loaded for the current terminal using the following command, depending on your shell:
+   thor-linux-64 --completions <bash/zsh/fish/powershell>
 
-- bash:
+Load the generated snippet into the current shell with one of the
+following commands:
 
-   ``source <(thor-linux-64 --completions bash)``
-
-- zsh:
-
-   ``source <(thor-linux-64 --completions zsh)``
-
-- fish:
-
-   ``thor-linux-64 --completions fish | source``
-
-- PowerShell:
-
-   ``thor64.exe --completions powershell | Out-String | Invoke-Expression``
+* bash: ``source <(thor-linux-64 --completions bash)``
+* zsh: ``source <(thor-linux-64 --completions zsh)``
+* fish: ``thor-linux-64 --completions fish | source``
+* PowerShell:
+  ``thor64.exe --completions powershell | Out-String | Invoke-Expression``
 
 Verify Public Key Signatures (optional)
 ---------------------------------------
 
-You can verify the executable files in the THOR package with
+You can verify the executable files in the THOR package using one of
+the following methods:
 
 * their digital signature (PE signature) issued by "Nextron Systems GmbH"
 * thor-util's "verify" feature
 * openssl verifying the integrity of executables manually
 
-Find more information on THOR Util in its dedicated `online manual <https://thor-util-manual.nextron-systems.com>`__.
+Find more information on THOR Util in its dedicated
+`online manual <https://thor-util-manual.nextron-systems.com>`__.
 
 .. hint::
    THOR Util automatically verifies the signatures of the contained
-   binaries in an update package and exits if one or more signatures cannot
-   be verified. You don't have to check them manually unless you distrust
-   the THOR Util itself. In this case, you can use the public key published
-   on `our web page <https://www.nextron-systems.com/pki/>`__.
+   binaries in an update package and exits if one or more signatures
+   cannot be verified. You do not need to check them manually unless you
+   do not trust THOR Util itself. In that case, you can use the public
+   key published on `our web page <https://www.nextron-systems.com/pki/>`__.
 
-After downloading the public key the signatures can be manually verified with the following command:
+After downloading the public key, you can manually verify the signatures
+with the following command:
 
 .. code-block:: doscon
 


### PR DESCRIPTION
## Summary
- improve the wording and flow of the maintenance chapter
- clarify update guidance, preview signatures, and YARA Forge usage
- clean up the macOS, shell completion, and signature verification sections

## Testing
- not run (documentation-only change)