### PR TITLE
docs: refine fundamentals index wording

### DIFF
--- a/core/index.rst
+++ b/core/index.rst
@@ -3,12 +3,12 @@
 Fundamentals
 ============
 
-In this chapter we will go over the fundamentals of THOR.
-This also includes licensing, compatibility with certain
-operating systems, updating THOR and its signatures, as well
-as general information. The aim of this manual is to give
-you all the information needed to use THOR to its full
-extend.
+This chapter covers the fundamentals of THOR. It includes licensing,
+compatibility with supported operating systems, updating THOR and its
+signatures, and other general information.
+
+The aim of this manual is to give you the information needed to use
+THOR effectively.
 
 .. toctree::
     :caption: Contents
@@ -22,4 +22,3 @@ extend.
     maintenance
     av-edr-exclusions
     score
-


### PR DESCRIPTION
## Summary
- improve the wording of the Fundamentals index page
- tighten the introductory description and remove awkward phrasing
- align the overview text with the updated terminology used elsewhere in the manual

## Testing
- not run (documentation-only change)