### PR TITLE
docs: refine scan templates wording

### DIFF
--- a/core/templates.rst
+++ b/core/templates.rst
@@ -3,58 +3,56 @@
 Scan Templates
 ==============
 
-THOR accepts config files (called "templates") in YAML format. They
-reflect all command options to make them flexible and their use as
-comfortable as possible.
+THOR supports YAML-based configuration files, referred to as
+"templates". They map to THOR's command-line options and provide a
+flexible way to define scan settings.
 
-This means that every parameter set via command line can be provided in
-the form of a config file. You can even combine several of these config
-files in a single scan run.
+This means that every parameter that can be set on the command line can
+also be provided in a configuration file. You can also combine multiple
+template files in a single scan run.
 
 Default Template
 ^^^^^^^^^^^^^^^^
 
-By default, THOR only applies the file named ``thor.yml`` in the
-``./config`` sub folder. Other config files can be applied using the
-``-t`` command line parameter.
+By default, THOR applies only the file named ``thor.yml`` in the
+``./config`` subfolder. Additional config files can be applied with the
+``-t`` command-line parameter.
 
 Apply Custom Scan Templates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following command line provides a custom scan template named
-``mythor.yml`` in the ``config`` directory.
+The following command applies a custom scan template named
+``mythor.yml`` from the ``config`` directory.
 
 .. code-block:: doscon
-   
-  C:\thor>thor.exe -t config\mythor.yml
+
+   C:\thor>thor.exe -t config\mythor.yml
 
 Example Templates
 ^^^^^^^^^^^^^^^^^
 
-The default config ``thor.yml`` in the ``./config`` folder has the
-following content.
-
-Content of THOR's Default Config ``thor.yml``:
+The default config file ``thor.yml`` in the ``./config`` folder has the
+following content:
 
 .. literalinclude:: ../examples/thor.yml
    :language: yaml
    :linenos:
 
-Content of Config File ``mythor.yml``:
+Example content of a custom config file ``mythor.yml``:
 
 .. literalinclude:: ../examples/mythor.yml
    :language: yaml
    :linenos:
 
 The default scan template is always applied first. Custom templates can
-then overwrite settings in the default template. In the example above,
-the ``cpu-limit`` and ``file-size-limit`` parameters are overwritten by
+then override settings from the default template. In the example above,
+the ``cpu-limit`` and ``file-size-limit`` parameters are overridden by
 the custom template.
 
-As you can see in the example file, you have to use the long form of the
-command line parameter (e.g. ``remote-log``) and not the short form (e.g.
-``-s``) in the template files. The long forms can be looked up in the
-command line help using ``--help full``.
+As shown in the example file, template files must use the long form of
+command-line parameters (for example ``remote-log``), not the short form
+(for example ``-s``). You can look up the long forms in the command-line
+help with ``--help full``.
 
 .. figure:: ../images/image20.png
    :alt: Lookup command line parameter long forms using --help full


### PR DESCRIPTION
## Summary
- improve the wording of the scan templates chapter
- clarify how default and custom templates are applied
- make the YAML and command-line guidance more concise and consistent

## Testing
- not run (documentation-only change)