### PR TITLE
docs: refine AV and EDR exclusions wording

### DIFF
--- a/core/av-edr-exclusions.rst
+++ b/core/av-edr-exclusions.rst
@@ -1,22 +1,22 @@
 .. Index:: Antivirus & EDR Exclusions
 
-Antivirus & EDR Exclusion
--------------------------
+Antivirus & EDR Exclusions
+==========================
 
-Since THOR accesses different process memories and probes for malicious
-Mutex, Named Pipes and Event values, it is recommended to exclude THOR
-from Antivirus / EDR scanning.
+Because THOR accesses process memory and probes for suspicious mutexes,
+named pipes, and event values, we recommend excluding THOR from
+antivirus and EDR scanning.
 
-The Antivirus exclusion could also lead to a significant runtime
-reduction, since access to processes memory and files will not get
-intercepted anymore.
+Adding such exclusions can also significantly reduce runtime, because
+access to process memory and files is no longer intercepted.
 
 .. note::
-   We have seen massive runtime changes with Windows Defender since April 2021 (+50-100%).
-   It is highly recommended to exclude THOR from scanning when using Windows Defender.
+   We have seen major runtime increases with Windows Defender since
+   April 2021 (+50-100%). When using Windows Defender, we strongly
+   recommend excluding THOR from scanning.
 
-The quickest way to add an exclusion on a single system is with the following command
-(change the path in ``-ExclusionProcess`` accordingly).
+The quickest way to add an exclusion on a single system is to use the
+following command. Adjust the path in ``-ExclusionProcess`` as needed.
 
 Windows command line:
 
@@ -30,23 +30,27 @@ PowerShell:
 
    PS C:\Users\nextron>Add-MpPreference -ExclusionProcess 'c:\temp\thor\thor64.exe'
 
-For more information, visit `https://docs.microsoft.com <https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/configure-process-opened-file-exclusions-microsoft-defender-antivirus?view=o365-worldwide>`__.
+For more information, see
+`the Microsoft documentation <https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/configure-process-opened-file-exclusions-microsoft-defender-antivirus?view=o365-worldwide>`__.
 
 A Note on SentinelOne
 ^^^^^^^^^^^^^^^^^^^^^
 
-The process memory of systems running SentinelOne is polluted with suspicious strings.
-The most prevalent false positive is related to the keyword "ReflectiveLoader",
-but any other rule can match as well.
+On systems running SentinelOne, process memory may contain suspicious
+strings introduced by the product itself. The most common false positive
+is related to the keyword ``ReflectiveLoader``, but other rules may also
+match.
 
-It is unclear what SentinelOne does to the process memory of many system processes.
-We cannot exclude these signatures from the scan. Be aware that the results from
-the "ProcessCheck" module on a system running SentinelOne can contain many false positives.
+It is unclear how SentinelOne modifies the memory of many system
+processes. We cannot generally exclude these signatures from the scan.
+Be aware that results from the ``ProcessCheck`` module on a system
+running SentinelOne may contain many false positives.
 
 A Note on McAfee
 ^^^^^^^^^^^^^^^^
 
-It is not an easy task to define exclusions for THOR in all the different services
-when running McAfee products. You have to exclude the process in different sections
-(AV, EDR, On-Access). We've compiled a list of exclusions for our ASGARD customers,
-which you can find `here <https://asgard-manual.nextron-systems.com/en/latest/requirements/av_edr.html#mcafee-edr-exclusions>`__.
+Defining THOR exclusions across all relevant McAfee services is not
+straightforward. You need to exclude the process in multiple sections
+(AV, EDR, On-Access). For ASGARD customers, we have compiled a list of
+recommended exclusions, which you can find
+`here <https://asgard-manual.nextron-systems.com/en/latest/requirements/av_edr.html#mcafee-edr-exclusions>`__.


### PR DESCRIPTION
## Summary
- improve the wording and heading structure of the AV and EDR exclusions chapter
- clarify the rationale for exclusions and the Windows Defender note
- tighten the SentinelOne and McAfee guidance for readability

## Testing
- not run (documentation-only change)