### PR TITLE
docs: refine deployment index wording

### DIFF
--- a/deployment/index.rst
+++ b/deployment/index.rst
@@ -3,8 +3,8 @@
 Deployment
 ==========
 
-This chapter lists different ways to deploy THOR in an environment. Most
-of these methods are OS specific.
+This chapter describes different ways to deploy THOR in an environment.
+Most of these methods are OS-specific.
 
 .. toctree::
     :caption: Contents


### PR DESCRIPTION
## Summary
- improve the wording of the deployment section index
- tighten the introductory description
- keep the chapter structure unchanged

## Testing
- not run (documentation-only change)