### PR TITLE
docs: refine ASGARD deployment wording

### DIFF
--- a/deployment/amc.rst
+++ b/deployment/amc.rst
@@ -1,33 +1,33 @@
 .. Index:: ASGARD Management Center
 
 ASGARD Management Center
-------------------------
+========================
 
 ASGARD is the central management platform for THOR scans. It manages
-distributed THOR scans on thousands of systems, collects, forwards and
-analyses logs. Furthermore, ASGARD can control and execute complex
-response tasks if needed.
+distributed THOR scans across thousands of systems, collects and
+forwards logs, and supports log analysis. It can also control and
+execute complex response tasks when needed.
 
-ASGARD comes in two variations: While ASGARD Management Center features
-scan control and response functions, ASGARD Analysis Cockpit can be used
-to analyze large amounts of scan logs through an integrated base-lining
-and case management.
+ASGARD is available in two variants. ASGARD Management Center focuses on
+scan control and response functions, while ASGARD Analysis Cockpit is
+used to analyze large volumes of scan logs through integrated
+baselining and case management.
 
-The hardened, Linux-based ASGARD appliance is a powerful, solid and
-scalable response platform with agents for Windows, Linux and macOS. It
-provides essential response features like the collection of files,
-directories and main memory, remote file system browsing and other
-counteractive measures.
+The hardened, Linux-based ASGARD appliance is a scalable response
+platform with agents for Windows, Linux, and macOS. It provides
+essential response features such as collecting files, directories, and
+main memory, browsing remote file systems, and executing additional
+response measures.
 
-It features templates for scan runs and lets you plan and schedule
-distributed sweeps with the lowest impact on system resources. Other
-services are:
+It provides templates for scan runs and lets you plan and schedule
+distributed sweeps with minimal impact on system resources. Additional
+services include:
 
 * **Update Service** - automatic updates for THOR scanners
-* **License Service** - central registration and sub license generation
+* **License Service** - central registration and sublicense generation
 * **Asset Management Service** - central inventory and status dashboard
-* **IOC Management** – manage and scan with custom IOC and YARA rule sets
-* **Evidence Collection** – collect evidences (files and memory) from asset
+* **IOC Management** - manage and scan with custom IOC and YARA rule sets
+* **Evidence Collection** - collect evidence (files and memory) from assets
 
 .. figure:: ../images/amc-assets.png
    :alt: ASGARD Management Center


### PR DESCRIPTION
## Summary
- improve the wording and heading structure of the ASGARD deployment chapter
- clarify the distinction between ASGARD Management Center and Analysis Cockpit
- reduce marketing-heavy phrasing in the appliance and services description

## Testing
- not run (documentation-only change)