### PR TITLE
docs: refine THOR Remote wording

### DIFF
--- a/deployment/thor-remote.rst
+++ b/deployment/thor-remote.rst
@@ -1,16 +1,16 @@
 .. Index:: THOR Remote
 
 THOR Remote
------------
+===========
 
-THOR Remote is a quick method to distribute THOR in a Windows
-environment. It has been developed during an incident response and can
-be considered as a clever hack that makes use of PsExec to push and
-execute THOR with certain parameters on remote systems.
+THOR Remote is a quick way to distribute THOR in a Windows environment.
+It was developed for incident response use cases and uses PsExec to
+push and execute THOR with selected parameters on remote systems.
 
 Requirements:
 
-* Administrative Domain Windows user account with access rights on the target systems
+* Administrative Windows domain user account with access rights on the
+  target systems
 * Reachability of the target systems (Windows Ports):
 
   - 135/tcp for SCM (Service Management)
@@ -22,35 +22,36 @@ Requirements:
 Advantages:
 
 * Agent-less
-* Comfortable scanning without scripting
+* Convenient scanning without scripting
 * Quick results (useful in incident response scenarios)
 
 Disadvantages:
 
 * Requires reachability of Windows ports
-* User credentials remain on the target system if it is used with explicit credentials
-  (NTLM Auth) and the users doesn't already use an account that has access rights on
-  target systems (Kerberos Auth)
+* User credentials remain on the target system if THOR Remote is used
+  with explicit credentials (NTLM authentication) and the user is not
+  already working with an account that has access rights on the target
+  systems (Kerberos authentication)
 
 Usage
 ^^^^^
 
-A list of parameters used with the remote scanning function can be found
-in the help screen.
+A list of parameters for the remote scanning function can be found in
+the help screen.
 
 .. figure:: ../images/image10.png
    :alt: THOR Remote Usage
 
    THOR Remote Usage
 
-As you can see, a list of target hosts can be provided with the help of
-the new YAML config files. See :ref:`core/templates:scan templates` for more
+As shown there, you can provide a list of target hosts using YAML
+configuration files. See :ref:`core/templates:scan templates` for more
 details.
 
 A YAML file with a list of hosts looks like this:
 
 .. code-block:: yaml
-   
+
    remote-host:
    - winatl001.dom.int
    - winatl002.dom.int
@@ -59,7 +60,7 @@ A YAML file with a list of hosts looks like this:
 You can then use that file with:
 
 .. code-block:: doscon
-   
+
    C:\thor>thor64.exe -t targets.yml
 
 THOR Remote Licensing
@@ -70,9 +71,9 @@ program folder or any sub folder within the program directory (e.g.
 ``./licenses``). In case of incident response licenses, just place that
 single license in the program folder.
 
-You don't need a valid license for the system that runs THOR's remote
-scanning feature (the source system of the scans, e.g. admin
-workstation).
+You do not need a valid license for the system that runs THOR's remote
+scanning feature, for example the administrator workstation used as the
+source system.
 
 .. hint::
    You can pair THOR Remote with the :ref:`core/licensing:customer portal`
@@ -82,11 +83,10 @@ Output
 ^^^^^^
 
 The generated log files are collected and written to the folder
-``./remote-logs``
+``./remote-logs``.
 
-The "THOR Remote" function has its own interface, which allows you to
-view the progress of the scans, view and scroll through the log files of
-the different remote systems.
+THOR Remote has its own interface, which allows you to monitor scan
+progress and view the log files of the different remote systems.
 
 .. figure:: ../images/image11.png
    :alt: THOR Remote Interface
@@ -100,14 +100,15 @@ System Error 5 occurred – Access Denied
 """""""""""""""""""""""""""""""""""""""
 
 See:
-https://helgeklein.com/blog/access-denied-trying-to-connect-to-administrative-shares-on-windows-7/
+`Access denied trying to connect to administrative shares on Windows 7 <https://helgeklein.com/blog/access-denied-trying-to-connect-to-administrative-shares-on-windows-7/>`_
 
 Running THOR from a Network Share
 """""""""""""""""""""""""""""""""
 
-THOR must reside on the local file system of the source system. Don't run
-it from a mounted network share. This could lead to the following error:
+THOR must reside on the local file system of the source system. Do not
+run it from a mounted network share. This can lead to the following
+error:
 
 .. code-block:: none
-   
+
    CreateFile .: The system cannot find the path specified.


### PR DESCRIPTION
## Summary
- improve the wording and heading structure of the THOR Remote chapter
- clarify requirements, usage, and licensing guidance
- clean up the issue notes and replace the raw support link with a labeled link

## Testing
- not run (documentation-only change)