### PR TITLE
docs: refine Velociraptor deployment wording

### DIFF
--- a/deployment/velociraptor.rst
+++ b/deployment/velociraptor.rst
@@ -3,9 +3,10 @@
 Velociraptor
 ============
 
-We created `Velociraptor artifacts <https://github.com/NextronSystems/velociraptor-artifacts-thor>`_,
-which you can use within your Velociraptor environment to run
-THOR and collect its output.
+We provide `Velociraptor artifacts <https://github.com/NextronSystems/velociraptor-artifacts-thor>`_
+that you can use in your Velociraptor environment to run THOR and
+collect its output.
 
-We also wrote a `blog article <https://www.nextron-systems.com/2023/11/03/integration-of-thor-in-velociraptor-supercharging-digital-forensics-and-incident-response/>`_
-which explains how this integration works in more detail.
+We also published a
+`blog article <https://www.nextron-systems.com/2023/11/03/integration-of-thor-in-velociraptor-supercharging-digital-forensics-and-incident-response/>`_
+that explains this integration in more detail.


### PR DESCRIPTION
## Summary
- improve the wording of the Velociraptor deployment chapter
- make the artifact and blog references read more cleanly
- keep the content and references unchanged otherwise

## Testing
- not run (documentation-only change)