### PR TITLE
docs: refine scan modes wording

### DIFF
--- a/scanning/scan-modes.rst
+++ b/scanning/scan-modes.rst
@@ -3,57 +3,62 @@
 Scan Modes
 ==========
 
-You can select between six different scan modes in THOR:
+THOR provides several scan modes:
 
 - **Default**
 
-  We recommend using the default scan mode for all sweeping activities. Scans take
-  from one to six hours, depending on the partition size and number of interesting files.
-  
-  In default mode, THOR automatically chooses  the "**Soft**" mode if the system has only limited
-  CPU and RAM resources.
+  We recommend the default scan mode for most broad scanning
+  activities. Scan duration typically ranges from one to six hours,
+  depending on partition size and the number of relevant files.
+
+  In default mode, THOR automatically switches to **Soft** mode if the
+  system has limited CPU or RAM resources.
 
 - **Fast** ``--fast``
 
-  This mode is the fastest one and oriented on the "Pareto Principle", covering 80% of
-  the modules and checks in 20% of the normal scan time. In fast mode, THOR skips
-  elements that have not been created or modified within the last 2 days in the "Eventlog",
-  "Registry" and "Filescan" modules. A set of 40+ predefined directories will still be checked
-  completely (e.g. AppData, Recycler, System32). Fast mode is known to be the
-  "preventive" scan mode – less intense and very fast.
+  This is the fastest scan mode. It follows a "Pareto Principle"
+  approach by covering around 80% of the modules and checks in about 20%
+  of the normal scan time. In fast mode, THOR skips elements that were
+  not created or modified within the last two days in the ``Eventlog``,
+  ``Registry``, and ``Filescan`` modules. A set of more than 40
+  predefined directories is still checked completely, for example
+  ``AppData``, ``Recycler``, and ``System32``. Fast mode is typically
+  used as a quick preventive scan.
 
-Themed scan modes:
+Additional scan modes:
 
 - **Soft** ``--soft`` - force disable with ``--no-soft``
 
-  This mode disables all modules and checks that could be risky for system stability. It furthermore
-  tries to reduce RAM usage of THOR.
+  This mode disables modules and checks that could put system stability
+  at risk. It also tries to reduce THOR's RAM usage.
   It is automatically activated on:
-  
+
   - Systems with only a single CPU core
-  
   - Systems with less than 1024 MB of RAM
 
-* **Deep** ``--deep``
+- **Deep** ``--deep``
 
-  This mode is meant for system scanning in a non-productive or lab environment. It
-  disables several speed optimizations and enables time-consuming extra checks for
-  best detection results. Be careful with this mode on database servers, as this
-  could corrupt your database due to the high load of the server. Snapshots/backups
-  are advised before using this mode.
+  This mode is intended for system scanning in non-productive or lab
+  environments. It disables several speed optimizations and enables
+  time-consuming additional checks for the best possible detection
+  results. Be careful when using this mode on database servers, as the
+  high system load can put service stability at risk. Snapshots or
+  backups are recommended before using this mode.
 
-* **Difference** ``--delta``
+- **Difference** ``--delta``
 
-  The Delta mode looks for a last scan and last finished modules in the local THOR
-  DB and scans only elements on disk that have been changed or created since the last
-  scan start. This mode applies shortcuts to the "Filesystem", "Eventlog" and "Registry"
-  modules. Delta scans are typically the shortest scans but require a completed previous
-  scan. This scan mode is also susceptible to the so-called "Timestomping".
+  Delta mode looks for the last scan and the last completed modules in
+  the local THOR database, then scans only elements on disk that were
+  changed or created since the previous scan started. This mode applies
+  shortcuts to the ``Filesystem``, ``Eventlog``, and ``Registry``
+  modules. Delta scans are typically the shortest scans, but they
+  require a previously completed scan. This scan mode is also
+  susceptible to so-called "timestomping".
 
-These scan modes can also be combined, e.g. for ``--soft --delta``, though not
-all combinations may make sense, e.g. ``--soft --deep``.
+These scan modes can also be combined, for example ``--soft --delta``.
+Not every combination is useful, for example ``--soft --deep``.
 
-The following tables give an overview on the active modules and features
-in the different scan modes. The :ref:`scanning/modules:modules` section lists
-all available modules, whereas the :ref:`scanning/features:features` section
-lists only features that are handled differently in the different scan modes.
+For more detail on module coverage and scan behavior, see
+:ref:`scanning/modules:modules` for the full list of available modules
+and :ref:`scanning/features:features` for features that behave
+differently across scan modes.


### PR DESCRIPTION
## Summary
- tighten the wording in the scan modes chapter
- make the distinctions between the modes easier to read
- correct small structural inconsistencies on the page

## Testing
- not run (documentation-only change)