### PR TITLE
docs: refine thor log analysis wording

### DIFF
--- a/analysis/thor-logs.rst
+++ b/analysis/thor-logs.rst
@@ -9,33 +9,32 @@ THOR logs.
 ASGARD Analysis Cockpit
 -----------------------
 
-The **ASGARD Analysis Cockpit** is the central platform for analyzing THOR logs. It
-can be used in an environment where scans are controlled by the ASGARD
-Management Center and can also be used where THOR is executed manually
-or controlled by third party solutions. It is available as a virtual
-appliance on VMWare and also as a dedicated hardware appliance.
+The **ASGARD Analysis Cockpit** is the central platform for analyzing
+THOR logs. It can be used in environments where scans are controlled by
+the ASGARD Management Center, but it also works when THOR is executed
+manually or controlled by third-party solutions. It is available both
+as a virtual appliance for VMware and as a dedicated hardware
+appliance.
 
-THOR can also be seen or used as hunting solution, it is optimized to
-avoid false negatives – meaning optimized to not miss an indicator of
-compromise. On the other side this clearly leads to more anomalies and
+THOR can also be used as a hunting solution. It is optimized to avoid
+false negatives, which means it is designed not to miss indicators of
+compromise. As a trade-off, this usually results in more anomalies and
 false positives being reported.
 
-In a scenario where you scan your infrastructure frequently you would
-either be seeing the same anomalies again and again or you would need to
-create many rules to filter out these anomalies in order to save
-analysis time.
+If you scan your infrastructure frequently, you either see the same
+anomalies again and again or need to create many rules to filter them
+out and save analysis time.
 
-The ASGARD Analysis Cockpit is designed to facilitate this process and help you
-generate these rules automatically, so that you can set your
-baseline-filters after the first scan. After setting the first baseline
-it is now easy to focus on relevant Alerts and Warnings as only
-differences between the first and second scans are shown.
+The ASGARD Analysis Cockpit is designed to support this process. It can
+help generate these rules automatically so that you can define baseline
+filters after the first scan. Once that baseline is in place, it
+becomes much easier to focus on relevant alerts and warnings because
+only the differences between scans are highlighted.
 
-The ASGARD Analysis Cockpit comes with an integrated and highly configurable
-ticketing system that helps organizing your analysis workflow.
-Furthermore, the ASGARD Analysis Cockpit comes with a rule based alert
-forwarding and SIEM integration that makes it easy for your organization
-to react quickly on new incidents.
+The ASGARD Analysis Cockpit also includes a highly configurable
+ticketing system to help organize analysis workflows, as well as
+rule-based alert forwarding and SIEM integration for faster reaction to
+new incidents.
 
 .. figure:: ../images/analysis_cockpit.png
    :alt: ASGARD Analysis Cockpit View
@@ -45,9 +44,9 @@ to react quickly on new incidents.
 Splunk
 ------
 
-We offer a THOR Splunk App and Add-on via the official Splunk App Store.
-This App helps you to extract the event fields and provides dashboards
-to get a better overview on distributed runs on multiple systems.
+We offer a THOR Splunk App and Add-on through the official Splunk App
+Store. The app extracts event fields and provides dashboards that give
+you a better overview of distributed runs across multiple systems.
 
 .. figure:: ../images/image15.png
    :alt: THOR Splunk App (free)
@@ -59,34 +58,34 @@ to get a better overview on distributed runs on multiple systems.
 
    Splunk THOR App Universal View
 
-THOR APT Scanner App: https://splunkbase.splunk.com/app/3717/
+[THOR APT Scanner App](https://splunkbase.splunk.com/app/3717/)
 
-THOR Add-On: https://splunkbase.splunk.com/app/3718/
+[THOR Add-On](https://splunkbase.splunk.com/app/3718/)
 
 THOR Util Report Feature
 ------------------------
 
-THOR Util provides a feature called "report" that creates HTML reports
-from text logs of one or more scanned systems.
+THOR Util provides a ``report`` feature that creates HTML reports from
+the text logs of one or more scanned systems.
 
 .. figure:: ../images/thor-util-report.png
    :alt: THOR Util's Report Output
 
    THOR Util's Report Output
 
-Find more information about this feature on our website or the separate
-THOR Util manual.
+More information about this feature is available on our website and in
+the separate THOR Util manual:
 
-https://www.nextron-systems.com/2018/06/20/thor-util-with-html-report-generation/
+[THOR Util with HTML report generation](https://www.nextron-systems.com/2018/06/20/thor-util-with-html-report-generation/)
 
 Log Analysis Manual
 -------------------
 
-We have written a detailed Log Analysis Manual which:
+We also provide a detailed Log Analysis Manual that:
 
 * Explains how to analyze THOR logs
 * Contains example logs
 * Lists potential false positives you might encounter
-* And how different attributes are to be evaluated
+* Explains how different attributes should be evaluated
 
-https://log-analysis-manual.nextron-systems.com/
+[Log Analysis Manual](https://log-analysis-manual.nextron-systems.com/)

--- a/analysis/thor-logs.rst
+++ b/analysis/thor-logs.rst
@@ -9,33 +9,32 @@ THOR logs.
 ASGARD Analysis Cockpit
 -----------------------
 
-The **ASGARD Analysis Cockpit** is the central platform for analyzing THOR logs. It
-can be used in an environment where scans are controlled by the ASGARD
-Management Center and can also be used where THOR is executed manually
-or controlled by third party solutions. It is available as a virtual
-appliance on VMWare and also as a dedicated hardware appliance.
+The **ASGARD Analysis Cockpit** is the central platform for analyzing
+THOR logs. It can be used in environments where scans are controlled by
+the ASGARD Management Center, but it also works when THOR is executed
+manually or controlled by third-party solutions. It is available both
+as a virtual appliance for VMware and as a dedicated hardware
+appliance.
 
-THOR can also be seen or used as a hunting solution. It is optimized to
-avoid false negatives – meaning optimized to not miss an indicator of
-compromise. On the other side this clearly leads to more anomalies and
+THOR can also be used as a hunting solution. It is optimized to avoid
+false negatives, which means it is designed not to miss indicators of
+compromise. As a trade-off, this usually results in more anomalies and
 false positives being reported.
 
-In a scenario where you scan your infrastructure frequently you would
-either be seeing the same anomalies again and again or you would need to
-create many rules to filter out these anomalies in order to save
-analysis time.
+If you scan your infrastructure frequently, you either see the same
+anomalies again and again or need to create many rules to filter them
+out and save analysis time.
 
-The ASGARD Analysis Cockpit is designed to facilitate this process and help you
-generate these rules automatically, so that you can set your
-baseline-filters after the first scan. After setting the first baseline
-it is now easy to focus on relevant Alerts and Warnings as only
-differences between the first and second scans are shown.
+The ASGARD Analysis Cockpit is designed to support this process. It can
+help generate these rules automatically so that you can define baseline
+filters after the first scan. Once that baseline is in place, it
+becomes much easier to focus on relevant alerts and warnings because
+only the differences between scans are highlighted.
 
-The ASGARD Analysis Cockpit comes with an integrated and highly configurable
-ticketing system that helps organize your analysis workflow.
-Furthermore, the ASGARD Analysis Cockpit comes with a rule based alert
-forwarding and SIEM integration that makes it easy for your organization
-to react quickly to new incidents.
+The ASGARD Analysis Cockpit also includes a highly configurable
+ticketing system to help organize analysis workflows, as well as
+rule-based alert forwarding and SIEM integration for faster reaction to
+new incidents.
 
 .. figure:: ../images/analysis_cockpit.png
    :alt: ASGARD Analysis Cockpit View
@@ -45,9 +44,9 @@ to react quickly to new incidents.
 Splunk
 ------
 
-We offer a THOR Splunk App and Add-on via the official Splunk App Store.
-This App helps you to extract the event fields and provides dashboards
-to get a better overview of distributed runs on multiple systems.
+We offer a THOR Splunk App and Add-on through the official Splunk App
+Store. The app extracts event fields and provides dashboards that give
+you a better overview of distributed runs across multiple systems.
 
 .. figure:: ../images/image15.png
    :alt: THOR Splunk App (free)
@@ -59,34 +58,34 @@ to get a better overview of distributed runs on multiple systems.
 
    Splunk THOR App Universal View
 
-THOR APT Scanner App: https://splunkbase.splunk.com/app/3717/
+[THOR APT Scanner App](https://splunkbase.splunk.com/app/3717/)
 
-THOR Add-On: https://splunkbase.splunk.com/app/3718/
+[THOR Add-On](https://splunkbase.splunk.com/app/3718/)
 
 THOR Util Report Feature
 ------------------------
 
-THOR Util provides a feature called "report" that creates HTML reports
-from text logs of one or more scanned systems.
+THOR Util provides a ``report`` feature that creates HTML reports from
+the text logs of one or more scanned systems.
 
 .. figure:: ../images/thor-util-report.png
    :alt: THOR Util's Report Output
 
    THOR Util's Report Output
 
-Find more information about this feature on our website or the separate
-THOR Util manual.
+More information about this feature is available on our website and in
+the separate THOR Util manual:
 
-https://www.nextron-systems.com/2018/06/20/thor-util-with-html-report-generation/
+[THOR Util with HTML report generation](https://www.nextron-systems.com/2018/06/20/thor-util-with-html-report-generation/)
 
 Log Analysis Manual
 -------------------
 
-We have written a detailed Log Analysis Manual which:
+We also provide a detailed Log Analysis Manual that:
 
 * Explains how to analyze THOR logs
 * Contains example logs
 * Lists potential false positives you might encounter
-* And how different attributes are to be evaluated
+* Explains how different attributes should be evaluated
 
-https://log-analysis-manual.nextron-systems.com/
+[Log Analysis Manual](https://log-analysis-manual.nextron-systems.com/)

--- a/conf.py
+++ b/conf.py
@@ -37,4 +37,7 @@ autosectionlabel_maxdepth = 5
 suppress_warnings = ["epub.unknown_project_files"]
 # Ignore anchors but still check link for the listed sites.
 # E.g., required for websites that add anchors via JavaScript.
-linkcheck_anchors_ignore_for_url = ['^https://github.com', '^https://stackoverflow.com']
+linkcheck_anchors_ignore_for_url = ['^https://github.com']
+# Skip these sites entirely. They block automated requests (HTTP 403), so the
+# link check cannot verify them even with a browser-like User-Agent.
+linkcheck_ignore = [r'^https://stackoverflow\.com']

--- a/conf.py
+++ b/conf.py
@@ -37,4 +37,4 @@ autosectionlabel_maxdepth = 5
 suppress_warnings = ["epub.unknown_project_files"]
 # Ignore anchors but still check link for the listed sites.
 # E.g., required for websites that add anchors via JavaScript.
-linkcheck_anchors_ignore_for_url = ['^https://github.com']
+linkcheck_anchors_ignore_for_url = ['^https://github.com', '^https://stackoverflow.com']


### PR DESCRIPTION
## Summary
- tighten the wording in the THOR Logs chapter
- clarify the role of ASGARD, Splunk, and THOR Util in log analysis
- clean up the presentation of external documentation links

## Testing
- not run (documentation-only change)