### PR TITLE
docs: refine scan output wording

### DIFF
--- a/output/scan-output.rst
+++ b/output/scan-output.rst
@@ -1,54 +1,55 @@
 .. Index:: Scan Output
 
 Scan Output
------------
+===========
 
 THOR creates several files during and at the end of the scan.
 
 * **Real Time**
-  
-  * the text and json log files are written during the scan process.
-    Also the SYSLOG output is sent in real-time to one or more remote
+
+  * The text and JSON log files are written during the scan process.
+    Syslog output is also sent in real time to one or more remote
     systems.
 
 * **End of Scan**
 
-  * the full HTML report and CSV file with all file scan
-    elements reported as suspicious are written at the end of the scan.
+  * The full HTML report and the CSV file with suspicious Filescan
+    elements are written at the end of the scan.
 
 You can define different formatting options for both text log and
-SYSLOG output.
+syslog output.
 
 JSON File Output (.jsonl)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The JSON log file is written by default. It provides the scan results
-in a structured, machine readable format. See https://github.com/NextronSystems/jsonlog
-for a detailed description and schema of the output format.
+The JSON log file is written by default. It provides scan results in a
+structured, machine-readable format. See the
+[JSON log schema](https://github.com/NextronSystems/jsonlog) for a
+detailed description of the format.
 
 * **--no-json**
-  
-  * Don't create a JSON log file
+
+  * Do not create a JSON log file
 
 Log File Output (.txt)
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The text log file is written only when explicitly enabled. It provides the
-text log format that was default for THOR 10.
+The text log file is written only when explicitly enabled. It provides
+the text log format that was the default in THOR 10.
 
 * **--text log.txt**
-  
+
   * Create a text log file
 
-The log file's format aligns with the format of SYSLOG messages. This
-way it can easily be imported to most SIEM or log analysis systems.
+The log file format matches the format of syslog messages, which makes
+it easy to import into most SIEM or log analysis systems.
 
 CSV Output (.csv)
 ^^^^^^^^^^^^^^^^^
 
-The CSV output is an optional legacy output file without much details.
-It contains only “Filescan” module findings and consist of 3 columns,
-file hash, file path and score.
+CSV output is an optional legacy output format with limited detail. It
+contains only ``Filescan`` findings and consists of three columns:
+file hash, file path, and score.
 
 CSV File Output:
 
@@ -56,24 +57,24 @@ CSV File Output:
    :language: none
    :linenos:
 
-If you need more information than the CSV provides, consider processing the JSON
-output instead.
+If you need more detail than the CSV file provides, use the JSON output
+instead.
 
 CSV Stats
 ^^^^^^^^^
 
-The CSV stats file is an optional output file that contains only the
-scan statistics. It contains a single line with:
+The CSV stats file is an optional output file that contains only scan
+statistics. It consists of a single line with:
 
  - Hostname
  - Scan start
  - Scan end
  - THOR version
  - Command line flags
- - number of alerts
- - number of warnings
- - number of notices
- - number of errors
+ - Number of alerts
+ - Number of warnings
+ - Number of notices
+ - Number of errors
 
 CSV Stats Output:
 
@@ -84,14 +85,14 @@ CSV Stats Output:
 Placeholders
 ^^^^^^^^^^^^
 
-Two placeholders can be used in command line parameters to facilitate
-the use of parameter on different operating systems.
+Two placeholders can be used in command-line parameters to make them
+easier to reuse across operating systems.
 
 * <hostname>
 * <time>
 
-These can be used in command line parameters and scan templates across
-all platforms.
+These placeholders can be used in command-line parameters and scan
+templates across all platforms.
 
 .. code-block:: doscon
 
@@ -100,38 +101,42 @@ all platforms.
 Console Output
 ^^^^^^^^^^^^^^
 
-The output THOR writes to the console is based on the text log format, but excludes some information in the header
-(e.g. the time for each log entry).
+The output THOR writes to the console is based on the text log format,
+but excludes some header information, for example the time of each log
+entry.
 
 It can be customized with the following flags:
 
 * **--console-json**
-  
-  * Print JSON format into the console (e.g. used with Splunk
-    scripted input)
+
+  * Print JSON to the console, for example for Splunk scripted input
 
 * **--console-key-value**
-  
-  * Print console output in a ``KEY="VALUE"`` format (e.g. used with Splunk
-    scripted input)
+
+  * Print console output in ``KEY="VALUE"`` format, for example for
+    Splunk scripted input
 
 Audit trail
 ^^^^^^^^^^^
 
-Audit trail output is different from the other output options.
-Usually, THOR only prints elements (e.g. files, or registry entries) that have been matched on by some signature.
-Audit trail mode, on the other hand, contains _all_ scanned elements, even those that THOR considers inconspicuous,
-as well as their relations to each other.
+Audit trail output differs from the other output options. Usually, THOR
+prints only elements such as files or registry entries that matched a
+signature. Audit trail mode, by contrast, contains *all* scanned
+elements, including those that THOR considers inconspicuous, as well as
+their relations to each other.
 
-This information can be used to visualize these elements, and help with grouping suspicious elements or laterally
-finding more suspicious elements.
+This information can be used to visualize relationships between
+elements, group suspicious items, and discover additional suspicious
+elements laterally.
 
 Output format
 ~~~~~~~~~~~~~
 
-Audit trail output is a gzipped JSON file. The file can be specified with ``--audit-trail my-target-file.json.gz``.
+Audit trail output is written as a gzipped JSON file. The output file
+can be specified with ``--audit-trail my-target-file.json.gz``.
 
-The file contains newline delimited JSON. where each contained JSON object follows the following schema:
+The file contains newline-delimited JSON. Each JSON object follows the
+following schema:
 
 .. code-block:: json
 
@@ -159,35 +164,36 @@ The file contains newline delimited JSON. where each contained JSON object follo
       ]
    }
 
-- ``id`` contains a unique ID for the element that was matched on
-- ``object`` contains the element that was matched on
+- ``id`` contains a unique ID for the element
+- ``object`` contains the matched element
 - ``timestamps`` contains all timestamps found within this element
-- ``reasons`` contains a list of signatures that matched on this element
-- ``references`` contains a list of IDs of other elements that this element referred to in some way
+- ``reasons`` contains a list of signatures that matched this element
+- ``references`` contains a list of IDs of other elements referenced by
+  this element
 
 Timestamps
 ^^^^^^^^^^
 
-Timestamp in all modules are using the  **ANSI C** format:
+Timestamps in all modules use the **ANSI C** format:
 
 .. code-block:: none
 
    Mon Jan  2 15:04:05 2006
    Mon Mar 19 09:04:05 2018
 
-https://go.dev/src/time/format.go
+[Go time format reference](https://go.dev/src/time/format.go)
 
 UTC
 ~~~
 
-The ``--timestamp-utc`` parameter allows to use UTC in all timestamps.
+The ``--timestamp-utc`` parameter forces all timestamps to use UTC.
 
 RFC3339 Time Stamps
 ~~~~~~~~~~~~~~~~~~~
 
-The parameter ``--timestamp-rfc3339`` generates time stamps for UTC time in the
-format described in RFC 3339. In contrast to the default time stamps RFC
-3339 timestamps include a year and look like this:
+The ``--timestamp-rfc3339`` parameter generates UTC timestamps in the
+RFC 3339 format. Unlike the default format, RFC 3339 timestamps include
+the year and look like this:
 
 .. list-table::
 
@@ -196,19 +202,19 @@ format described in RFC 3339. In contrast to the default time stamps RFC
 SCAN ID
 ^^^^^^^
 
-The parameter ``-scan-id`` allows users to set a certain scan ID
-(SCANID) that appears in every log line.
+The ``-scan-id`` parameter allows you to set a specific scan ID
+(``SCANID``) that appears in every log line.
 
-The scan ID helps SIEM and analysis systems to correlate the scan lines
-from multiple scans on a single host. Otherwise it would be very
-difficult to answer the following questions:
+The scan ID helps SIEM and analysis systems correlate log lines from
+multiple scans on a single host. Without it, questions such as the
+following become difficult to answer:
 
 * How many scans completed successfully on a certain endpoint?
 * Which scan on a certain endpoint terminated during the scan run?
 
-If no parameter is set, THOR will automatically generate a random scan
-ID, which starts with an ``S-`` and contains the following
-characters: ``a-zA-Z0-9_-``
+If no parameter is set, THOR automatically generates a random scan ID
+that starts with ``S-`` and uses the characters
+``a-zA-Z0-9_-``.
 
 .. list-table::
    :header-rows: 1
@@ -217,12 +223,13 @@ characters: ``a-zA-Z0-9_-``
    * - S-Rooa61RfuuM
    * - S-0vRKu-1\_p7A
 
-Users can overwrite the scan ID with ``-scan-id myscanid`` to assign the logs of
-multiple scan runs to a single logical scan, e.g. if multiple partitions
-of a system get scanned in the lab in different scan runs, but should be
-shown as a single scan in Analysis Cockpit or your SIEM of choice.
+You can override the scan ID with ``-scan-id myscanid`` to assign the
+logs of multiple scan runs to a single logical scan, for example when
+different partitions of a system are scanned separately in the lab but
+should appear as a single scan in Analysis Cockpit or a SIEM.
 
-In a log line, it looks like (set newlines and shortened for readability):
+In a log line, it looks like this, with line breaks added and content
+shortened for readability:
 
 .. code-block:: none
 
@@ -240,23 +247,25 @@ In a log line, it looks like (set newlines and shortened for readability):
 Custom Scan ID Prefix
 ~~~~~~~~~~~~~~~~~~~~~
 
-You are able to set you custom prefix by using
-``--scan-id-prefix``. The fixed character "S" can be replaced with any
-custom string. This allows users to set an identifier for a group of
-scans that can be grouped together in a SIEM or Analysis Cockpit.
+You can set a custom prefix with ``--scan-id-prefix``. The fixed
+character ``S`` can be replaced with any custom string. This allows you
+to define an identifier for a group of scans that should be grouped
+together in a SIEM or Analysis Cockpit.
 
 Personal Information
 ^^^^^^^^^^^^^^^^^^^^
 
-THOR features an option named ``--no-personal-data`` that allows to filter the output
-messages and replace all known locations and fields that can contain
-user names or user ids with the value ``ANONYMIZED_BY_THOR``.
+THOR provides a ``--no-personal-data`` option that filters output
+messages and replaces known locations and fields that may contain user
+names or user IDs with the value ``ANONYMIZED_BY_THOR``.
 
-What it does is:
+Specifically, it:
 
-* Replace all "USER" and "OWNER" field values of all modules with the anonymized string value
-* Replaced the subfolder names of ``C:\Users`` and ``C:\Documents and Settings`` with the anonymized string value
+* Replaces all ``USER`` and ``OWNER`` field values in all modules with
+  the anonymized string
+* Replaces subfolder names under ``C:\Users`` and
+  ``C:\Documents and Settings`` with the anonymized string
 
-There is no guarantee that all user IDs will be removed by the filter,
-as they may appear in the most unexpected locations, but in most cases
-this approach is sufficient to comply with data protection requirements.
+There is no guarantee that all user identifiers will be removed, as
+they can appear in unexpected locations. In most cases, however, this
+approach is sufficient to support data protection requirements.


### PR DESCRIPTION
## Summary
- tighten the wording throughout the scan output chapter
- clarify the purpose of the different output formats and related flags
- align the page heading level with the other standalone chapters

## Testing
- not run (documentation-only change)