### PR TITLE
docs: refine encrypted output wording

### DIFF
--- a/output/encryption.rst
+++ b/output/encryption.rst
@@ -1,20 +1,21 @@
 .. Index:: Encryption
 
 Encrypted Output Files
-----------------------
+======================
 
-THOR allows to encrypt the output files of each scan using the
-``--encryption-key`` parameter. This parameter must receive an RSA public key of 1024,
-2048 or 4096 bit size in PEM format.
+THOR can encrypt the output files of each scan by using the
+``--encryption-key`` parameter. This parameter expects an RSA public key
+in PEM format with a size of 1024, 2048, or 4096 bits.
 
 .. code-block:: doscon
  
    C:\thor>thor64.exe --encryption-key mykey-public.pem
 
-THOR Util can be used to decrypt the logs later on: 
+You can decrypt the logs later with THOR Util:
 
 .. code-block:: console
 
    nextron@unix:~$ thor-util decrypt --privkey mykey-private.pem thorlog.json
 
-For more information on "thor-util" see the separate `THOR Util manual <https://thor-util-manual.nextron-systems.com/>`__.
+For more information about ``thor-util``, see the separate `THOR Util
+manual <https://thor-util-manual.nextron-systems.com/>`__.


### PR DESCRIPTION
## Summary
- tighten the wording in the encrypted output chapter
- align the page heading level with the other standalone chapters
- keep the change limited to wording and structure

## Testing
- not run (documentation-only change)