### PR TITLE
docs: refine signature scoring wording

### DIFF
--- a/signatures/scores.rst
+++ b/signatures/scores.rst
@@ -1,20 +1,20 @@
 Scoring
 =======
 
-All signatures contain a score. Signature scores can be between -100 and 100;
-negative values are used to reduce the score on elements that are prone
-to false positives, positive scores increase the score of elements that they
-match on.
+All signatures contain a score. Signature scores can range from ``-100``
+to ``100``. Negative values reduce the score of elements that are prone
+to false positives, while positive values increase the score of the
+elements they match.
 
 For more details about scoring, see :ref:`core/score:Scoring System`.
 
-How the score is specified depends on the signature format. See the specific
-chapter for each format (YARA, Sigma, ...) for more information.
+How the score is specified depends on the signature format. See the
+format-specific chapters, such as YARA or Sigma, for more information.
 
 Examples
 ^^^^^^^^
 
-False Positive Rule:
+Example false-positive rule:
 
 .. code-block:: yara
    :linenos:


### PR DESCRIPTION
## Summary
- tighten the wording in the signature scoring chapter
- clarify how negative and positive scores affect findings
- keep the change limited to wording and structure

## Testing
- not run (documentation-only change)