### PR TITLE
docs: refine debugging chapter intro

### DIFF
--- a/debugging/index.rst
+++ b/debugging/index.rst
@@ -3,8 +3,8 @@
 Debugging
 =========
 
-This chapter contains information and help if you need
-to debug issues or runtime errors of THOR.
+This chapter contains guidance for troubleshooting THOR issues,
+unexpected behavior, and runtime errors.
 
 .. toctree::
     :caption: Contents


### PR DESCRIPTION
## Summary
- tighten the wording in the debugging chapter intro
- keep the change limited to wording and structure
- preserve the existing chapter layout

## Testing
- not run (documentation-only change)