### PR TITLE
docs: refine debug output wording

### DIFF
--- a/debugging/debug.rst
+++ b/debugging/debug.rst
@@ -1,37 +1,39 @@
 .. Index:: Debug Output
 
 Debug Output
-------------
+============
 
-Most unexpected behavior can be debugged by using the parameter ``--debug``.
+Many unexpected behaviors can be investigated by using the
+``--debug`` parameter.
 
-This can be useful if you ever encounter a situation in which:
+This can be useful in situations such as:
 
-* THOR doesn't produce an alert on a known malicious element
+* THOR does not produce an alert for a known malicious element
 * THOR exits with an error
-* THOR takes a long time or unexpected short time on elements
+* THOR takes unexpectedly long, or unusually short, on specific
+  elements
 
 Debugging Examples
 ------------------
 
-If you found the culprit for your problematic scan, try scanning that
-specific element with the ``--debug`` parameter set. For example,
-a specific file seems to cause problems during a THOR scan. You can
-use the ``Filescan`` module to only scan this file and see the debug
-output of THOR:
+If you identified the element that causes problems during a scan, try
+scanning that specific element with ``--debug`` enabled. For example,
+if a single file appears to cause problems during a THOR scan, you can
+use the ``Filescan`` module to scan only that file and review THOR's
+debug output:
 
 .. code-block:: doscon
 
    C:\thor>thor64.exe -a Filescan -p C:\tools\file --debug
 
-The above command will:
+The command above will:
 
 - Only use the Filescan module (``-a Filescan``)
 - Only scan a single file (``-p C:\tools\file``)
-- Enable THORs debug output (``--debug``)
+- Enable THOR's debug output (``--debug``)
 
-To run a scan only with certain module(s), use the ``--module`` (short hand ``-a``)
-command line switch :
+To run a scan with only specific modules, use the ``--module``
+parameter, or its short form ``-a``:
 
 .. code-block:: doscon
 
@@ -40,29 +42,31 @@ command line switch :
    C:\thor>thor64.exe -a Eventlog
 
 .. hint::
-   You can specify multiple modules within one command (see :ref:`scanning/modules:modules`
-   for a full list of module names):
+   You can specify multiple modules in a single command. See
+   :ref:`scanning/modules:modules` for a full list of module names.
 
    .. code-block:: doscon
 
       C:\thor>thor64.exe -a Mutex,EnvCheck,Users
 
-You can try to reduce the scope of a module even further by using ``--lookback``:
+You can reduce the scope of some modules even further by using
+``--lookback``:
 
 .. code-block:: doscon
 
    C:\thor>thor64.exe -a Eventlog --lookback 3
    C:\thor>thor64.exe -a FileScan -p C:\Windows\System32 --lookback-global --lookback 1
 
-To find out why a certain file couldn't be detected, use
-``--debug`` with ``--log-object file`` and try to switch into ``--deep`` mode.
+To find out why a file was not detected, use ``--debug`` together with
+``--log-object file`` and, if needed, test the same path in
+``--deep`` mode.
 
 .. code-block:: doscon
 
    C:\thor>thor64.exe -a Filescan -p C:\testfolder --debug --log-object file
    C:\thor>thor64.exe -a Filescan -p C:\testfolder --debug --log-object file --deep
 
-If it has been detected in ``--deep`` mode but not in default mode,
-the file extension or the magic header is most likely the problem.
-You can adjust ``file-size-limit`` in ``./config/thor.yml`` or add a
-magic header in ``./signatures/misc/file-type-signatures.cfg``.
+If the file is detected in ``--deep`` mode but not in default mode, the
+file extension or the magic header is the most likely cause. You can
+adjust ``file-size-limit`` in ``./config/thor.yml`` or add a magic
+header in ``./signatures/misc/file-type-signatures.cfg``.


### PR DESCRIPTION
## Summary
- tighten the wording in the debug output chapter
- clarify when and how to use the debug flag and module scoping
- align the page heading level with the other standalone chapters

## Testing
- not run (documentation-only change)