### PR TITLE
docs: refine diagnostics pack wording

### DIFF
--- a/debugging/diag.rst
+++ b/debugging/diag.rst
@@ -1,16 +1,16 @@
 .. Index:: Diagnostics Pack
 
 Diagnostics Pack
-----------------
+================
 
-THOR Util comes with the functionality to collect a diagnostics pack for
-THOR scans. This is helpful if a scan is taking more time as expected
-or if THOR exits unexpectedly. More details can be found in the
-`diagnostics section of THOR Util <https://thor-util-manual.nextron-systems.com/en/latest/usage/diagnostics.html>`_.
+THOR Util can collect a diagnostics pack for THOR scans. This is useful
+if a scan is taking longer than expected or if THOR exits unexpectedly.
+More details can be found in the `diagnostics section of THOR Util
+<https://thor-util-manual.nextron-systems.com/en/latest/usage/diagnostics.html>`_.
 
-Diagnostics packs should be created while the THOR scan is still running (e.g.
-while THOR is taking an unusually high amount of RAM, taking a long time on a
-single element, etc.).
+Diagnostics packs should be created while the THOR scan is still
+running, for example when THOR is using an unusually high amount of RAM
+or spending a long time on a single element.
 
 To create a diagnostics pack, run:
 
@@ -18,5 +18,6 @@ To create a diagnostics pack, run:
    
    C:\thor>thor-util.exe diagnostics
 
-It will connect to the running THOR, query different information (e.g. about
-allocated memory, threads, etc.) and gather them in a single ZIP.
+The tool connects to the running THOR process, collects diagnostic
+information such as allocated memory and thread state, and writes
+everything to a single ZIP archive.


### PR DESCRIPTION
## Summary
- tighten the wording in the diagnostics pack chapter
- clarify when to collect a diagnostics pack and what it contains
- align the page heading level with the other standalone chapters

## Testing
- not run (documentation-only change)