### PR TITLE
docs: refine frozen scans troubleshooting wording

### DIFF
--- a/debugging/frozen-scans.rst
+++ b/debugging/frozen-scans.rst
@@ -3,24 +3,26 @@
 Most Frequent Causes of Frozen Scans
 ------------------------------------
 
-Whenever THOR stops or pauses without any traceback or panic message
-and no error messages, usually the following sources are responsible
-(descending order, by frequency):
+If THOR stops or appears to pause without a traceback, panic message, or
+other error output, one of the following causes is usually
+responsible (in descending order of frequency):
 
 1. An :ref:`debugging/frozen-scans:antivirus or edr suspends thor` (>98%)
-2. A "paused" command line window due to :ref:`debugging/frozen-scans:windows quick edit mode` (<1%)
-3. A :ref:`debugging/frozen-scans:constant high system load` that causes THOR to stay back and wait for an idling CPU (<1%)
-4. :ref:`debugging/frozen-scans:the perception of a stalled scan`, which is actually running (<1%)
+2. A paused command-line window due to :ref:`debugging/frozen-scans:windows quick edit mode` (<1%)
+3. :ref:`debugging/frozen-scans:constant high system load`, which causes THOR to wait for CPU time (<1%)
+4. :ref:`debugging/frozen-scans:the perception of a stalled scan`, even though the scan is still running (<1%)
 
 Antivirus or EDR suspends THOR
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In more than 98% of the cases, an Antivirus or EDR is responsible for a
-stalled process. Especially McAfee AV/EDR is a well-known source of issues. This
-is caused by the different dialogues in which exceptions have to be defined and
-the fact certain kinds of blocks cannot be found in any logs.
+In more than 98% of cases, an antivirus or EDR product is responsible
+for a stalled process. McAfee AV/EDR is a particularly common source of
+issues. This is often caused by the different places in which
+exceptions must be defined and by the fact that some types of blocks do
+not appear in any logs.
 
-If a THOR scans stalls in one of these modules, an Antivirus or EDR interaction is highly likely:
+If a THOR scan stalls in one of these modules, antivirus or EDR
+interaction is highly likely:
 
 * Mutex
 * Events
@@ -28,43 +30,48 @@ If a THOR scans stalls in one of these modules, an Antivirus or EDR interaction 
 * ShimCache
 * ProcessCheck
 
-**Solution**: Review all possible exclusions in your AV / EDR and add the THOR folder to the exclusion list
+**Solution**: Review all available exclusions in your AV or EDR product
+and add the THOR folder to the exclusion list.
 
 Windows Quick Edit Mode
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Since Windows 10, the Windows command line window has the so-called "Quick Edit Mode"
-enabled by default. This mode causes a behavior that can lead to a paused THOR scan
-process. Whenever a user switches the active windows from the cmd.exe to a different
-application, e.g. Windows Explorer, and clicks back into the command line window, the
-running process automatically gets suspended. A user has to press "Enter" to resume
-the suspended process. As the progress indicator of THOR isn't always changing, this
-could lead to the impression that the scan paused by itself.
+On modern Windows systems, the command-line window often has "Quick
+Edit Mode" enabled by default. This can pause a running THOR scan
+without producing an error message. In this situation, the process
+resumes only after the user presses ``Enter``. Because the THOR
+progress indicator does not change constantly, this can look like the
+scan paused by itself.
 
 See `this StackOverflow post <https://stackoverflow.com/questions/30418886/how-and-why-does-quickedit-mode-in-command-prompt-freeze-applications>`_ for more details.
 
-**Solution**: Press "Enter" in the command line window
+**Solution**: Press ``Enter`` in the command-line window.
 
 Constant High System Load
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Since THOR automatically sets a low process priority a scan can slow down to a level
-that appears to be paused or suspended on systems that are under a constant high load.
+THOR automatically sets a low process priority. On systems that are
+under constant high load, a scan can therefore slow down to a level
+that appears to be paused.
 
-**Solution**: You can avoid this behavior by using the ``--no-low-priority`` flag. Be aware
-that scans on a system with a constant high CPU load take longer than on other systems
-and could slow down the processes that would otherwise take all the CPU capacity.
+**Solution**: You can avoid this behavior by using the
+``--no-low-priority`` flag. Keep in mind that scans on systems with a
+constant high CPU load will still take longer than on other systems and
+may slow down other processes.
 
 The Perception of a Stalled Scan
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Under certain circumstances the scan may appear stalled but is still running.
-You can always interrupt a scan using CTRL+C that brings THOR into the interrupt
-menu in which you can see the currently scanned element. In case of the "FileScan"
-module, this is a file or folder. In case of the "EventLog" module, this is an
-event with an ID. The amount of time spent on this element is also printed.
+Under certain circumstances, the scan may appear stalled even though it
+is still running. You can always interrupt a scan using ``Ctrl+C``.
+This opens the interrupt menu, where you can see the element that THOR
+is currently processing. In the ``FileScan`` module, this is a file or
+folder. In the ``EventLog`` module, it is an event with an ID. The time
+spent on this element is also shown.
 
-If THOR processes the same element for several hours, we recommend checking
-that element (size, format, access rights, location).
+If THOR processes the same element for several hours, we recommend
+checking that element, including its size, format, access rights, and
+location.
 
-**Solution**: Check progress using the interrupt menu (CTRL+C)
+**Solution**: Check the current progress using the interrupt menu
+(``Ctrl+C``).


### PR DESCRIPTION
## Summary
- clarify the most common causes of apparently frozen scans
- improve the AV/EDR, Quick Edit Mode, and system-load explanations
- make the recovery guidance easier to scan and follow

## Testing
- not run locally (documentation-only change)