### PR TITLE
docs: refine master update wording

### DIFF
--- a/usage/update.rst
+++ b/usage/update.rst
@@ -2,17 +2,18 @@
 Update
 ======
 
-You can download updates for THOR with "thor-util". 
+You can download updates for THOR with ``thor-util``.
 
 Running ``thor-util --help`` shows two options that look very similar:
 
 - **upgrade** : program and signature updates
 - **update** : signature updates only
 
-For more information on "thor-util" see the separate `THOR Util manual <https://thor-util-manual.nextron-systems.com>`__.
+For more information on ``thor-util``, see the separate
+`THOR Util manual <https://thor-util-manual.nextron-systems.com>`__.
 
 Update Locations
------------------
+----------------
 
 The following servers are used as update mirrors and should be
 accessible via HTTPS (443/tcp):
@@ -23,6 +24,6 @@ accessible via HTTPS (443/tcp):
 Update Server Information
 -------------------------
 
-You can get information on the available update packages on this site:
+You can find information on the available update packages here:
 
-https://update1.nextron-systems.com/info.php
+`update1.nextron-systems.com/info.php <https://update1.nextron-systems.com/info.php>`__


### PR DESCRIPTION
## Summary
- tighten the wording around upgrade and update commands
- clean up heading formatting and link presentation
- keep the page short and customer-facing

## Testing
- not run locally (documentation-only change)