### PR TITLE
docs: refine master links-and-references wording

### DIFF
--- a/usage/links-and-references.rst
+++ b/usage/links-and-references.rst
@@ -2,19 +2,19 @@
 Links and References
 ====================
 
-THOR Website: https://www.nextron-systems.com/thor/
+`THOR Website <https://www.nextron-systems.com/thor/>`__
 
-Nextron Customer Portal: https://portal.nextron-systems.com
+`Nextron Customer Portal <https://portal.nextron-systems.com>`__
 
-Nextron Support Portal: https://support.nextron-systems.com
+`Nextron Support Portal <https://support.nextron-systems.com>`__
 
-Nextron Knowledge Base: https://knowledge.nextron-systems.com
+`Nextron Knowledge Base <https://knowledge.nextron-systems.com>`__
 
-Nextron Hosts & IP: https://knowledge.nextron-systems.com/general/hosts-ip-addresses
+`Nextron Hosts & IP <https://knowledge.nextron-systems.com/general/hosts-ip-addresses>`__
 
-Nextron Software Update Status: https://update1.nextron-systems.com/info.php
+`Nextron Software Update Status <https://update1.nextron-systems.com/info.php>`__
 
-YARA Documentation: https://yara.readthedocs.io/en/latest/
+`YARA Documentation <https://yara.readthedocs.io/en/latest/>`__
 
 yarGen - YARA Rule Generator: https://github.com/Neo23x0/yarGen-Go
 
@@ -29,4 +29,3 @@ A up to date list of third-party software components used by
 THOR 10 with open source licensing requirements can be found
 in the file ``./docs/License_Acknowledgement.txt`` in your
 local THOR package.
-


### PR DESCRIPTION
## Summary
- replace raw URLs with proper link text
- improve readability of the references page without changing the destinations

## Testing
- not run locally (documentation-only change)