### PR TITLE
docs: refine master scan-modes wording

### DIFF
--- a/usage/scan-modes.rst
+++ b/usage/scan-modes.rst
@@ -1,28 +1,30 @@
 Scan Modes
 ==========
 
-You can select between six different scan modes in THOR:
+THOR provides several scan modes:
 
 - **Default**
 
-  We recommend using the default scan mode for all sweeping activities. Scans take
-  from one to six hours, depending on the partition size and number of interesting files.
+  We recommend the default scan mode for broad scanning activities.
+  Scans typically take between one and six hours, depending on
+  partition size and the number of relevant files.
   
-  In default mode, THOR automatically chooses  the "**Soft**" mode if the system has only limited
-  CPU and RAM resources.
+  In default mode, THOR automatically switches to **Soft** mode if the
+  system has limited CPU or RAM resources.
 
-  There's a special "Lab Scanning" (``--lab``) method described in section 
-  :ref:`usage/special-scan-modes:lab scanning`, which disables many limitations
-  and allows to scan mounted images in a Lab scenario, even with multiple THOR instances
-  on a single Workstation.
+  There is also a special Lab Scanning mode (``--lab``) described in
+  :ref:`usage/special-scan-modes:lab scanning`. It disables many
+  limitations and allows you to scan mounted images in a lab scenario,
+  even with multiple THOR instances on a single workstation.
 
   .. note::
     "Lab Scanning" requires a special forensic license.
 
 - **Quick** ``--quick``
 
-  This mode is the fastest one and oriented on the "Pareto Principle", covering 80% of
-  the modules and checks in 20% of the normal scan time: 
+  This is the fastest scan mode. It follows a "Pareto Principle"
+  approach by covering around 80% of the modules and checks in about
+  20% of the normal scan time:
   
   - THOR skips elements that have not been created or modified within the last 3 days in "Filescan" modules
   
@@ -32,14 +34,15 @@ You can select between six different scan modes in THOR:
   
   - A set of 40+ predefined directories will still be checked completely (e.g. AppData, Recycler, System32)
   
-  "Quick" mode is known to be the "preventive" scan mode – less intense and very fast.
+  Quick mode is typically used as a fast preventive scan.
 
-Themed scan modes:
+Additional scan modes:
 
 - **Soft** ``--soft`` - force disable with ``--nosoft``
 
-  This mode disables all modules and checks that could be risky for system stability.
-  It is automatically activated on (more details in chapter :ref:`usage/other-topics:Automatic Soft Mode`):
+  This mode disables modules and checks that could put system stability
+  at risk. It is automatically activated on (see
+  :ref:`usage/other-topics:Automatic Soft Mode` for more details):
   
   - Systems with only a single CPU core
   
@@ -47,9 +50,9 @@ Themed scan modes:
 
 * **Lab Scan** ``--lab``
 
-  This mode scans only the file system and disables all other modules.
+  This mode scans only the file system and disables all other modules
   (see :ref:`usage/special-scan-modes:lab scanning` for more details
-  and flags used in this scan mode)
+  and the flags used in this scan mode).
   
   Example: 
   
@@ -59,24 +62,28 @@ Themed scan modes:
 
 * **Intense** ``--intense``
 
-  This mode is meant for system scanning in a non-productive or lab environment. It
-  disables several speed optimizations and enables time-consuming extra checks for
-  best detection results. Be careful with this mode on database servers, as this
-  could corrupt your database due to the high load of the server. Snapshots/backups
-  are advised before using this mode.
+  This mode is intended for scanning non-productive or lab
+  environments. It disables several speed optimizations and enables
+  time-consuming additional checks for the best possible detection
+  results. Be careful when using this mode on database servers, as the
+  high system load can put service stability at risk. Snapshots or
+  backups are recommended before using this mode.
 
 * **Difference** ``--diff``
 
-  The Diff Mode looks for a last scan and last finished modules in the local THOR
-  DB and scans only elements on disk that have been changed or created since the last
-  scan start. This mode applies shortcuts to the "Filesystem", "Eventlog" and "Registry"
-  modules. Diff scans are typically the shortest scans but require a completed previous
-  scan. This scan mode is also susceptible to the so-called "Timestomping".
+  Difference mode checks the last scan and the last completed modules
+  in the local THOR DB, then scans only elements on disk that were
+  changed or created since the previous scan started. This mode applies
+  shortcuts to the ``Filesystem``, ``Eventlog``, and ``Registry``
+  modules. Difference scans are typically the shortest scans, but they
+  require a previously completed scan. This scan mode is also
+  susceptible to so-called ``timestomping``.
 
   However, the contents of some APT-relevant folders are scanned again even though no changes have been made to them. This behavior can be adjusted with the ``--force-aptdir-lookback`` flag.
 
-These scan modes can also be combined, e.g. for ``--soft --diff``, though not
-all combinations may make sense, e.g. ``--soft --intense``.
+These scan modes can also be combined, for example ``--soft --diff``,
+although not every combination is useful, for example
+``--soft --intense``.
 
 The following tables give an overview on the active modules and features
 in the different scan modes. The :ref:`usage/scan-modes:modules` section lists
@@ -167,18 +174,18 @@ Scan Module Explanation
 Features
 --------
 
-Features are being invoked by :ref:`usage/scan-modes:modules` and provide
-further ``Details`` about an item. For example, the ``File System Scan``
-might find a ``.zip`` file during a scan and invoke the ``Archive Scan``
-feature. The ``Archive Scan`` feature in return will extract the zip file
-and scan all the items in it.
+Features are invoked by :ref:`usage/scan-modes:modules` and provide
+additional processing or details for an item. For example, the
+``File System Scan`` might find a ``.zip`` file during a scan and
+invoke the ``Archive Scan`` feature. The ``Archive Scan`` feature then
+extracts the archive contents and scans the contained items.
 
-Another example would be the ``Eventlog Analysis`` Module, which might invoke
-the ``Sigma Scan`` feature on certain eventlog entries.
+Another example is the ``Eventlog Analysis`` module, which might invoke
+the ``Sigma Scan`` feature for certain event log entries.
 
 .. hint:: 
-  Please see chapter :ref:`usage/other-topics:archive scan` for a list
-  of supported archive formats.
+  See :ref:`usage/other-topics:archive scan` for a list of supported
+  archive formats.
 
 Feature Scan Mode Overview
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -206,13 +213,13 @@ how they are called by the different modules and other features.
 
 Feature selectors
 ^^^^^^^^^^^^^^^^^
-Since THOR 10.7, some features in THOR are triggered by YARA rules.
+Since THOR 10.7, some THOR features are triggered by YARA rules.
 
 When a (meta or generic) YARA rule with a specific tag matches on a file, the
 corresponding feature is started and parses the file.
 
-The standard signatures contain a number of rules with these tags, but if required,
-you can add additional rules with these tags as custom signatures.
+The standard signatures contain a number of rules with these tags, but
+you can add more rules with these tags as custom signatures if needed.
 
 .. csv-table::
   :file: ../csv/feature-selector-list.csv


### PR DESCRIPTION
## Summary
- improve the explanatory wording for the main scan modes
- tighten the descriptions of feature behavior and feature selectors
- leave the underlying mode tables intact

## Testing
- not run locally (documentation-only change)