### PR TITLE
docs: refine master analysis wording

### DIFF
--- a/usage/analysis.rst
+++ b/usage/analysis.rst
@@ -2,39 +2,35 @@
 Analysis
 ========
 
-This chapter explains the possibilities for collecting and analyzing
-THOR logs.
+This chapter describes the available options for collecting and
+analyzing THOR logs.
 
 ASGARD Analysis Cockpit
 -----------------------
 
-The ANALYSIS COCKPIT is the central platform for analyzing THOR logs. It
-can be used in an environment where scans are controlled by ASGARD
-Management Center and can also be used where THOR is executed manually
-or controlled by third party solutions. It is available as a virtual
-appliance on VMWare and also as a dedicated hardware appliance.
+The ANALYSIS COCKPIT is the central platform for analyzing THOR logs.
+It can be used in environments where scans are controlled by the ASGARD
+Management Center, but also when THOR is executed manually or managed
+by third-party solutions. It is available as a virtual appliance on
+VMware and also as dedicated hardware.
 
-THOR can also be seen or used as hunting solution, it is optimized to
-avoid false negatives – meaning optimized to not miss an indicator of
-compromise. On the other side this clearly leads to more anomalies and
-false positives being reported.
+THOR is optimized to avoid false negatives, which means it is designed
+not to miss indicators of compromise. As a result, it also reports more
+anomalies and false positives than a narrowly tuned scanner.
 
-In a scenario where you scan your infrastructure frequently you would
-either be seeing the same anomalies again and again or you would need to
-create many rules to filter out these anomalies in order to save
-analysis time.
+In environments with regular scans, you would otherwise see the same
+anomalies repeatedly or have to create many rules to filter them out.
 
-The ANALYSIS COCKPIT is designed to facilitate this process and help you
-generate these rules automatically, so that you can set your
-baseline-filters after the first scan. After setting the first baseline
-it is now easy to focus on relevant Alerts and Warnings as only
-differences between the first and second scans are shown.
+The ANALYSIS COCKPIT is designed to make this process easier and can
+help you generate these rules automatically so that you can establish
+baseline filters after the first scan. Once the baseline is in place,
+you can focus on relevant alerts and warnings because only the
+differences between scans are highlighted.
 
-The ANALYSIS COCKPIT comes with an integrated and highly configurable
-ticketing system that helps organizing your analysis workflow.
-Furthermore, the ANALYSIS COCKPIT comes with a rule based alert
-forwarding and SIEM integration that makes it easy for your organization
-to react quickly on new incidents.
+The ANALYSIS COCKPIT also includes an integrated and highly
+configurable ticketing system to support analysis workflows. In
+addition, it offers rule-based alert forwarding and SIEM integration to
+help organizations react quickly to new incidents.
 
 .. figure:: ../images/analysis_cockpit.png
    :alt: Analysis Cockpit View
@@ -44,9 +40,9 @@ to react quickly on new incidents.
 Splunk
 ------
 
-We offer a THOR Splunk App and Add-on via the official Splunk App Store.
-This App helps you to extract the event fields and provides dashboards
-to get a better overview on distributed runs on multiple systems.
+We offer a THOR Splunk App and Add-on through the official Splunk App
+Store. These help extract event fields and provide dashboards for a
+better overview of distributed runs across multiple systems.
 
 .. figure:: ../images/image15.png
    :alt: THOR Splunk App (free)
@@ -58,9 +54,9 @@ to get a better overview on distributed runs on multiple systems.
 
    Splunk THOR App Universal View
 
-THOR APT Scanner App: https://splunkbase.splunk.com/app/3717/
+`THOR APT Scanner App <https://splunkbase.splunk.com/app/3717/>`__
 
-THOR Add-On:https://splunkbase.splunk.com/app/3718/
+`THOR Add-On <https://splunkbase.splunk.com/app/3718/>`__
 
 THOR Util Report Feature
 ------------------------
@@ -73,19 +69,19 @@ from text logs of one or more scanned systems.
 
    THOR Util's Report Output
 
-Find more information about this feature on our website or the separate
-THOR Util manual.
+Find more information about this feature on our website or in the
+separate THOR Util manual:
 
-https://www.nextron-systems.com/2018/06/20/thor-util-with-html-report-generation/
+`THOR Util with HTML report generation <https://www.nextron-systems.com/2018/06/20/thor-util-with-html-report-generation/>`__
 
 Log Analysis Manual
 -------------------
 
-We have written a detailed Log Analysis Manual which:
+We have written a detailed Log Analysis Manual that:
 
 * Explains how to analyze THOR logs
 * Contains example logs
 * Lists potential false positives you might encounter
-* And how different attributes are to be evaluated
+* Explains how different attributes should be evaluated
 
-https://log-analysis-manual.nextron-systems.com
+`log-analysis-manual.nextron-systems.com <https://log-analysis-manual.nextron-systems.com>`__


### PR DESCRIPTION
## Summary
- improve the wording in the Analysis Cockpit and Splunk sections
- replace raw links with proper link text
- tighten the description of the log analysis resources

## Testing
- not run locally (documentation-only change)