### PR TITLE
docs: refine master other-topics wording

### DIFF
--- a/usage/other-topics.rst
+++ b/usage/other-topics.rst
@@ -1,35 +1,32 @@
 
-Other Topics 
+Other Topics
 ============
 
 License Retrieval
 -----------------
 
-THOR allows for a more flexible way to fetch licenses,
-besides the classic way of placing a license file in
-the program folder. In this chapter we will show both
-available options for license retrieval.
+THOR offers more flexible ways to retrieve licenses in addition to the
+classic approach of placing a license file in the program folder. This
+chapter describes both available license retrieval options.
 
-It is important to know that those two options also
-work with :ref:`usage/deployment:thor remote`. In this
-case, all licenses will be downloaded to the host which
-is running the initial THOR Remote command (the host
-running THOR Remote does not need a license).
+These two options also work with :ref:`usage/deployment:thor remote`.
+In that case, all licenses are downloaded to the host that runs the
+initial THOR Remote command. The system running THOR Remote itself does
+not need a license.
 
 .. important::
-   If you have already a valid THOR license for your host
-   placed within THOR's program folder, no (new) license will
-   be downloaded/issued from the remote locations.
+   If a valid THOR license for the host is already present in THOR's
+   program folder, no new license will be downloaded or issued from the
+   remote source.
 
 ASGARD License Retrieval
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you are having a local instance of the ASGARD Management
-Center installed and using its license pool for your THOR
-scans, you can use the ``--asgard`` flag to download a valid
-license. This flag also needs the ``--asgard-token`` flag to
-work. The Token can be found in the **Download** section of
-your ASGARD Management Center.
+If you have a local ASGARD Management Center instance and use its
+license pool for THOR scans, you can use the ``--asgard`` flag to
+download a valid license. This also requires the ``--asgard-token``
+flag. The token can be found in the **Download** section of your
+ASGARD Management Center.
 
 Example:
 
@@ -39,34 +36,32 @@ Example:
   [...SNIP...]
   Info License file found LICENSE: my-asgard.local OWNER: John Doe TYPE: Server STARTS: 2023/08/30 EXPIRES: 2023/11/01 SCANNER: THOR VALID: true REASON:
 
-The retrieved license will be placed in the program folder of THOR,
-so you can run THOR the next time without all the extra flags.
-The name of the license is ``<hostname>.lic``. Rerunning the command
-will not issue a new license, but rather download the already valid
-license again from your ASGARD Management Center.
+The retrieved license is placed in THOR's program folder so that you
+can run THOR next time without the extra flags. The file name is
+``<hostname>.lic``. Rerunning the command does not issue a new license;
+it downloads the already valid license again from your ASGARD
+Management Center.
 
 Nextron Portal License Retrieval
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you are using standalone packages of THOR, you can speed up
-the process of deploying THOR by using its ``--portal-key``
-flag. This allows you to download a THOR license straight from
-the Licensing Portal, without the need to generate all the licenses
-and downloading them manually first. This is a good way to automate
-scanning.
+If you use standalone THOR packages, you can speed up deployment by
+using the ``--portal-key`` flag. This allows you to download a THOR
+license directly from the Licensing Portal without having to generate
+and download licenses manually first. This is a practical way to
+automate scanning.
 
-The argument ``--portal-key`` is expecting one argument, which can be
-one of:
+The ``--portal-key`` argument accepts one of the following values:
 
- - The API key of your Portal user
- - A download token for one of your contracts
+* The API key of your portal user
+* A download token for one of your contracts
 
-When using an API key, THOR will grab the first available license from
-the contract with the lowest ID and issue one to your host.
-No new license will be issued if a valid license was found for the host.
-If no valid license was found, a new one will be issued. This also means
-that you should provide the ``--portal-contracts`` flag if you want to
-limit THOR to a specific contract(s) for issuing/downloading licenses.
+When using an API key, THOR retrieves the first available license from
+the contract with the lowest ID and issues it to your host. No new
+license is issued if a valid license is already available for the host.
+If no valid license is found, a new one is issued. If you want to limit
+license issuance or downloads to specific contracts, provide the
+``--portal-contracts`` flag.
 
 Example:
 
@@ -76,11 +71,10 @@ Example:
    ...SNIP...
    Info License file found LICENSE: portal.nextron-systems.com OWNER: Jane Doe TYPE: Server STARTS: 2023/03/10 EXPIRES: 2023/09/29 SCANNER: THOR VALID: true REASON:
 
-The retrieved license will be placed in the program folder of THOR,
-so you can run THOR the next time without all the extra flags.
-The name of the license is ``<hostname>.lic``. Rerunning the command
-will not issue a new license, but rather download the already valid
-license again from the portal.
+The retrieved license is placed in THOR's program folder so that you
+can run THOR next time without the extra flags. The file name is
+``<hostname>.lic``. Rerunning the command does not issue a new license;
+it downloads the already valid license again from the portal.
 
 .. attention:: 
   If no valid license is found, a new one will be issued. This can be


### PR DESCRIPTION
## Summary
- improve the wording in the bundled license-retrieval sections
- clarify ASGARD and portal-based license download behavior
- keep the broader chapter structure intact

## Testing
- not run locally (documentation-only change)