### PR TITLE
docs: refine master flags wording

### DIFF
--- a/usage/flags.rst
+++ b/usage/flags.rst
@@ -1,7 +1,8 @@
 Command Line Options
 ====================
 
-This section lists all options that THOR currently offers.
+This section lists the command-line options currently available in
+THOR.
 
 Scan Options
 ----------------------------------------------------------------------
@@ -342,4 +343,3 @@ Debugging and Info
       -h, --help                    Show help for most important options and exit
       --fullhelp                Show help for all options and exit
       --completions string      Generate shell completions for the specified shell (bash, zsh, fish, powershell)
-


### PR DESCRIPTION
## Summary
- tighten the intro sentence of the command-line options page
- leave the generated option listing untouched

## Testing
- not run locally (documentation-only change)