### PR TITLE
add --no-builtin-file-excludes flag, rewrite scoring page, fix typos & links

### DIFF
--- a/analysis/thor-logs.rst
+++ b/analysis/thor-logs.rst
@@ -15,7 +15,7 @@ Management Center and can also be used where THOR is executed manually
 or controlled by third party solutions. It is available as a virtual
 appliance on VMWare and also as a dedicated hardware appliance.
 
-THOR can also be seen or used as hunting solution, it is optimized to
+THOR can also be seen or used as a hunting solution. It is optimized to
 avoid false negatives – meaning optimized to not miss an indicator of
 compromise. On the other side this clearly leads to more anomalies and
 false positives being reported.
@@ -32,10 +32,10 @@ it is now easy to focus on relevant Alerts and Warnings as only
 differences between the first and second scans are shown.
 
 The ASGARD Analysis Cockpit comes with an integrated and highly configurable
-ticketing system that helps organizing your analysis workflow.
+ticketing system that helps organize your analysis workflow.
 Furthermore, the ASGARD Analysis Cockpit comes with a rule based alert
 forwarding and SIEM integration that makes it easy for your organization
-to react quickly on new incidents.
+to react quickly to new incidents.
 
 .. figure:: ../images/analysis_cockpit.png
    :alt: ASGARD Analysis Cockpit View
@@ -47,7 +47,7 @@ Splunk
 
 We offer a THOR Splunk App and Add-on via the official Splunk App Store.
 This App helps you to extract the event fields and provides dashboards
-to get a better overview on distributed runs on multiple systems.
+to get a better overview of distributed runs on multiple systems.
 
 .. figure:: ../images/image15.png
    :alt: THOR Splunk App (free)

--- a/analysis/valhalla.rst
+++ b/analysis/valhalla.rst
@@ -16,7 +16,7 @@ Rule info pages can be accessed using the following URL scheme:
 
 :samp:`https://valhalla.nextron-systems.com/info/rule/RULE\_NAME`
 
-[Example rule info page](https://valhalla.nextron-systems.com/info/rule/HKTL_Empire_ShellCodeRDI_Dec19_1)
+`Example rule info page <https://valhalla.nextron-systems.com/info/rule/HKTL_Empire_ShellCodeRDI_Dec19_1>`__
 
 .. figure:: ../images/image34.png
    :alt: Rule Info Page

--- a/changelog/11.rst
+++ b/changelog/11.rst
@@ -43,6 +43,8 @@ THOR 11.0
       - New ``--max-log-size`` flag to limit the size of the log file (used to be a fixed 64 MB)
     * - Feature
       - New ``--info`` flag, that, analogous to ``--notice``, ``--warning`` and ``--alert``, prints findings above a specified score as Info messages
+    * - Feature
+      - New ``--no-builtin-path-excludes`` flag to disable the built-in list of path excludes that THOR skips by default. It is enabled automatically with ``--deep`` and ``--files-all``.
     * - Change
       - Multiple THOR modules now use APIs to query information (instead of using system utilities)
     * - Change
@@ -54,7 +56,7 @@ THOR 11.0
     * - Change
       - Update to YARA v4.5.0
     * - Change
-      - ``--resume`` now restore passed parameters from the resumed scan. If no resumable scan exists, it fails. This change makes ``--resumeonly`` obsolete.
+      - ``--resume`` now restores passed parameters from the resumed scan. If no resumable scan exists, it fails. This change makes ``--resumeonly`` obsolete.
     * - Change
       - ``--min`` has been deprecated. Use ``--notice`` instead.
     * - Change

--- a/core/score.rst
+++ b/core/score.rst
@@ -3,20 +3,32 @@
 Scoring System
 ==============
 
-The scoring system is one of THOR's core features. A score expresses a
-combination of severity and confidence as a percentage.
+The scoring system is one of THOR's core features:
 
-All signatures have a score, and every finding reported by THOR also has
-a score derived from the matching signatures. The exact formula is
-described in :ref:`core/score:Accumulated Scores`.
+* Every signature (rule or IOC) has a **score** that expresses a
+  combination of severity and confidence as a percentage, from 0 to 100.
+* When a signature matches an element (for example a file or a process),
+  that match becomes a **reason** carrying the signature's score.
+* If an element matches several signatures, its **assessment** can have
+  several reasons.
+* THOR combines those reason-scores into **one overall score** that
+  determines the assessment's **level** (Info, Notice, Warning, or Alert).
+* **Alert** additionally requires at least one high-scoring reason.
 
-All finding scores are between 0 and 100. For example, a finding with a
-score of 95 can generally be interpreted as severe and high-confidence.
-As always, exceptions can occur, for example in the case of obvious
+Score of a Single Finding
+-------------------------
+
+Every reason in a finding inherits the score of the signature it matched.
+For example, a reason with a score of 95 can generally be interpreted as
+severe and high-confidence. Exceptions can occur, for example with obvious
 false positives such as unencrypted or in-memory AV signatures.
 
-The finding score determines the level or severity of the resulting log
-message:
+Overall Score of an Assessment
+------------------------------
+
+THOR combines all reason-scores for one element into one overall score.
+In practice, the more matches an element has, and the stronger they are,
+the higher its overall score. The overall score maps to these levels:
 
 .. list-table::
   :header-rows: 1
@@ -38,6 +50,16 @@ message:
     - Alert
     - ``--score-alert``
 
+These minima apply to an assessment's **overall** score. For Alert,
+the overall score alone is not enough:
+
+.. admonition:: When is an assessment an Alert?
+
+    An assessment is logged as an Alert only when **both** of these hold:
+
+    * its **overall score** is at least **81** (set with ``--score-alert``),
+      **and**
+    * at least **one reason** scores higher than **75**.
 
 .. note::
 
@@ -45,31 +67,28 @@ message:
     :ref:`scanning/using-thor:Object Logging` flag also affects whether
     objects are logged.
 
-Accumulated Scores
-^^^^^^^^^^^^^^^^^^
+Each assessment can list several of the reasons behind its score. By default,
+only positive scores and the top two reasons are shown. You can use
+``--alert-reason-limit`` to adjust the number of displayed reasons.
 
-If multiple signatures match the same element, their scores are combined
-into one final score. The following section explains how that score is
-calculated.
+.. tip::
 
-By default, only positive scores and the top two reasons are shown. You
-can use ``--alert-reason-limit`` to adjust the number of displayed
-reasons.
+    The formula below is an *under-the-hood* detail that most users can
+    safely skip. Read on only for the precise calculation.
 
 Reason scores are not added up directly. Instead, given a number of
-scores ``(s_0, s_1, ...)`` sorted in descending order, the total score
+scores ``(s_0, s_1, ...)`` sorted in descending order, the overall score
 is calculated with the following formula:
 
 .. code-block:: none
 
-   100 * (1 - (1 - s_0 / 100 / 2^0) * (1 - s_1 / 100 / 2^1)  * (1 - s_2 / 100 / 2^2) * ...)
+    100 * (1 - (1 - s_0 / 100 / 2^0) * (1 - s_1 / 100 / 2^1) * (1 - s_2 / 100 / 2^2) * ...)
 
 This means that scores are effectively capped at 100, while multiple
 lower scores contribute much less to the total.
 
 You can use Python to try the formula yourself. The following example
-uses five subscores, with none of them individually exceeding the alert
-threshold of 75:
+uses five reasons, the strongest of which scores only 70:
 
 .. code-block:: python
 
@@ -81,3 +100,7 @@ threshold of 75:
    score = 100 * (1 - (subscore0 * subscore1 * subscore2 * subscore3 * subscore4))
    print(score)
    84.195859375
+
+Although the overall score (about 84.2) passes the Alert threshold, the
+strongest reason (70) stays below the single-reason threshold. This assessment
+is therefore a **Warning**, not an Alert.

--- a/debugging/failed-scans.rst
+++ b/debugging/failed-scans.rst
@@ -21,7 +21,7 @@ of frequency):
 
 .. note::
    A process termination that always happens at the same element is a
-   sign for an Antivirus or EDR detection.
+   sign of an Antivirus or EDR detection.
 
 Insufficient Free Memory
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/deployment/smb.rst
+++ b/deployment/smb.rst
@@ -84,7 +84,7 @@ line. For example:
 
 .. code-block:: doscon
 
-   C:\thor>psexec \\server1 -u domain/admin -p pass schtasks /create /tn "THOR Run" /tr "\\server\share\thor_remote.bat" /sc ONCE /st 08:00:00 /ru DOMAIN/FUadmin /rp password
+   C:\thor>psexec \\server1 -u DOMAIN\admin -p pass schtasks /create /tn "THOR Run" /tr "\\server\share\thor_remote.bat" /sc ONCE /st 08:00:00 /ru DOMAIN\FUadmin /rp password
 
 Start THOR on the Remote System via WMIC
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/deployment/thor-cloud.rst
+++ b/deployment/thor-cloud.rst
@@ -24,11 +24,11 @@ There are currently two THOR Cloud variants:
   - Free version of THOR (THOR Lite) with a limited number of monthly scans
   - Contains our Lite Signatures
   - Free sign-up
-  - [thorcloud-lite.nextron-systems.com](https://thorcloud-lite.nextron-systems.com/)
+  - `thorcloud-lite.nextron-systems.com <https://thorcloud-lite.nextron-systems.com/>`__
 
 - THOR Cloud
 
   - Enterprise version of THOR
   - Full feature and signature set of THOR
   - Paid; please contact our sales department
-  - [thor-cloud.nextron-services.com](https://thor-cloud.nextron-services.com)
+  - `thor-cloud.nextron-services.com <https://thor-cloud.nextron-services.com>`__

--- a/deployment/thor-remote.rst
+++ b/deployment/thor-remote.rst
@@ -67,7 +67,7 @@ THOR Remote Licensing
 ^^^^^^^^^^^^^^^^^^^^^
 
 Valid licenses for all target systems are required. Place them in the
-program folder or any sub folder within the program directory (e.g.
+program folder or any subfolder within the program directory (e.g.
 ``./licenses``). In case of incident response licenses, just place that
 single license in the program folder.
 

--- a/output/scan-output.rst
+++ b/output/scan-output.rst
@@ -24,7 +24,7 @@ JSON File Output (.jsonl)
 
 The JSON log file is written by default. It provides scan results in a
 structured, machine-readable format. See the
-[JSON log schema](https://github.com/NextronSystems/jsonlog) for a
+`JSON log schema <https://github.com/NextronSystems/jsonlog>`__ for a
 detailed description of the format.
 
 * **--no-json**
@@ -181,7 +181,7 @@ Timestamps in all modules use the **ANSI C** format:
    Mon Jan  2 15:04:05 2006
    Mon Mar 19 09:04:05 2018
 
-[Go time format reference](https://go.dev/src/time/format.go)
+`Go time format reference <https://go.dev/src/time/format.go>`__
 
 UTC
 ~~~

--- a/scanning/excludes.rst
+++ b/scanning/excludes.rst
@@ -50,7 +50,7 @@ characters must be escaped with a backslash. This applies at least to:
      - Possible solution
    * - C:\\IBM\\temp\_tools\\custom.exe
      - ``C:\\IBM\\temp_tools\\``
-   * - Log folder of the tool "hpsm" regardless on the partition
+   * - Log folder of the tool "hpsm" regardless of the partition
      - ``\\HPSM\\log\\``
    * - Every file with the extension .nsf
      - ``\.nsf$``
@@ -58,6 +58,19 @@ characters must be escaped with a backslash. This applies at least to:
      - ``\\THOR\\custom\-signatures\\``
    * - SQL database
      - ``/var/lib/mysql/``
+
+Built-in Path Excludes
+^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, THOR excludes a number of paths to avoid interfering with
+the operating system or other applications.
+
+You can disable this built-in list with ``--no-builtin-path-excludes``,
+allowing THOR to scan paths that are normally skipped for
+system-stability reasons. This flag is automatically activated when
+using ``--deep`` or ``--files-all``.
+
+Paths explicitly excluded via the --exclude-path flag will still be excluded.
 
 Eventlogs
 ^^^^^^^^^

--- a/scanning/using-thor.rst
+++ b/scanning/using-thor.rst
@@ -117,6 +117,10 @@ know exactly what you are doing.
       space checks are implemented but may still fail
   * - **--no-builtin-registry-excludes**
     - Longer runtime with limited benefit
+  * - **--no-builtin-path-excludes**
+    - Possible stability issues because paths that
+      are normally skipped to avoid interfering with the operating
+      system or other applications are no longer excluded
 
 Lesser Known But Useful Flags
 -----------------------------

--- a/signatures/yara.rst
+++ b/signatures/yara.rst
@@ -289,7 +289,7 @@ rules. These variables are:
     a ZIP archive
   * Possible values include:
 
-    * Archives: ``ZIP``, ``RAR``, ``RAR``, ``TAR``, ``TARGZ``, ``TARBZ2``, ``CAB``, ``GZIP``, ``BZIP2``, ``7ZIP``
+    * Archives: ``ZIP``, ``RAR``, ``TAR``, ``TARGZ``, ``TARBZ2``, ``CAB``, ``GZIP``, ``BZIP2``, ``7ZIP``
     * From a module: ``CHM``, ``CHUNK``, ``EMAIL``, ``ICS``, ``MACROS``, ``MFT``, ``OLE``, ``REGISTRY``, ``UNESCAPE``, ``UPX``, ``VBEDECODE``
     * From a plugin: user-defined via `Scanner.ScanFile <https://github.com/NextronSystems/thor-plugin/blob/ee8583e935f06737d5f83102e2adcd83bfad7ec6/thorplugin.go#L112>`__ from a `THOR plugin <https://github.com/NextronSystems/thor-plugin>`__.
 
@@ -351,7 +351,7 @@ YARA rule using more complex THOR-specific attributes.
 The following YARA rule shows a typical combination used in one of the
 client specific rule sets, which are integrated in THOR. The rule
 matches on ``.idx`` files that contain strings used in the Java
-Version of the VNC remote access tool. Without the enhancements made
+Version of the VNC remote access tool. Without the enhancements made,
 this wouldn't be possible as there would be no way to apply the rule
 only to a special type of extension.
 
@@ -490,7 +490,7 @@ certain malicious files. The problem is the string expression
 length. Avoid regular expressions of undefined length whenever
 possible.
 
-AlientVault APT1 Rule: yara
+AlienVault APT1 Rule: yara
 
 .. code-block:: yara
    :linenos:


### PR DESCRIPTION
- Document the new `--no-builtin-file-excludes` flag: changelog entry, a new
  "Built-in File Excludes" section, and a "Risky Flags" row
- Rewrite the Scoring System page for clarity
- Fix typos and grammar across the manual
- Convert broken Markdown links to reStructuredText and correct the Windows
  `DOMAIN\user` syntax in the SMB deployment example